### PR TITLE
Include windows.h from audiostream.h

### DIFF
--- a/ninjam/audiostream.h
+++ b/ninjam/audiostream.h
@@ -36,6 +36,9 @@
 #ifndef _AUDIOSTREAM_H_
 #define _AUDIOSTREAM_H_
 
+#ifdef _WIN32
+#include <windows.h> // for GUID
+#endif
 
 class audioStreamer
 {


### PR DESCRIPTION
The windows.h header needs to be included from audiostream.h because
create_audioStreamer_DS() takes a GUID argument.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
