### PR TITLE
Set work directory

### DIFF
--- a/ninjam/qtclient/MainWindow.h
+++ b/ninjam/qtclient/MainWindow.h
@@ -39,6 +39,8 @@ private:
   QTextEdit *chatOutput;
   QLineEdit *chatInput;
 
+  bool setupWorkDir();
+  void cleanupWorkDir(const QString &path);
   void OnSamples(float **inbuf, int innch, float **outbuf, int outnch, int len, int srate);
   void chatAddLine(const QString &prefix, const QString &content);
   void chatAddMessage(const QString &src, const QString &msg);


### PR DESCRIPTION
The client stores .ogg files in its work directory while running.  This series introduces work directory creation and deletion in the appropriate places when connecting and disconnecting from a server.

The work directory will be deleted when the client disconnects.  In the future we can add a setting for the work directory location and a setting to keep the work directory.  This is useful for saving and remixing jam sessions offline.
