### PR TITLE
Add GPL license headers to qtclient

### DIFF
--- a/ninjam/qtclient/ClientRunThread.cpp
+++ b/ninjam/qtclient/ClientRunThread.cpp
@@ -1,3 +1,21 @@
+/*
+    Copyright (C) 2012 Stefan Hajnoczi <stefanha@gmail.com>
+
+    Wahjam is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    Wahjam is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Wahjam; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
 #include "ClientRunThread.h"
 
 /*

--- a/ninjam/qtclient/ClientRunThread.h
+++ b/ninjam/qtclient/ClientRunThread.h
@@ -1,3 +1,21 @@
+/*
+    Copyright (C) 2012 Stefan Hajnoczi <stefanha@gmail.com>
+
+    Wahjam is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    Wahjam is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Wahjam; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
 #ifndef _CLIENTRUNTHREAD_H_
 #define _CLIENTRUNTHREAD_H_
 

--- a/ninjam/qtclient/ConnectDialog.cpp
+++ b/ninjam/qtclient/ConnectDialog.cpp
@@ -1,3 +1,21 @@
+/*
+    Copyright (C) 2012 Stefan Hajnoczi <stefanha@gmail.com>
+
+    Wahjam is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    Wahjam is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Wahjam; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
 #include <QLabel>
 #include <QFormLayout>
 #include <QPushButton>

--- a/ninjam/qtclient/ConnectDialog.h
+++ b/ninjam/qtclient/ConnectDialog.h
@@ -1,3 +1,21 @@
+/*
+    Copyright (C) 2012 Stefan Hajnoczi <stefanha@gmail.com>
+
+    Wahjam is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    Wahjam is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Wahjam; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
 #ifndef _CONNECTDIALOG_H_
 #define _CONNECTDIALOG_H_
 

--- a/ninjam/qtclient/MainWindow.cpp
+++ b/ninjam/qtclient/MainWindow.cpp
@@ -1,3 +1,21 @@
+/*
+    Copyright (C) 2012 Stefan Hajnoczi <stefanha@gmail.com>
+
+    Wahjam is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    Wahjam is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Wahjam; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
 #include <QMessageBox>
 #include <QVBoxLayout>
 

--- a/ninjam/qtclient/MainWindow.h
+++ b/ninjam/qtclient/MainWindow.h
@@ -1,3 +1,21 @@
+/*
+    Copyright (C) 2012 Stefan Hajnoczi <stefanha@gmail.com>
+
+    Wahjam is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    Wahjam is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Wahjam; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
 #ifndef _MAINWINDOW_H_
 #define _MAINWINDOW_H_
 

--- a/ninjam/qtclient/qtclient.cpp
+++ b/ninjam/qtclient/qtclient.cpp
@@ -1,3 +1,21 @@
+/*
+    Copyright (C) 2012 Stefan Hajnoczi <stefanha@gmail.com>
+
+    Wahjam is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    Wahjam is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Wahjam; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
 #include <QApplication>
 #include <QSettings>
 


### PR DESCRIPTION
Like the original NINJAM code, the qtclient is licensed under GPLv2 or
later.  Add explicit headers to all code where I forgot to do this.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
