### PR TITLE
Show useful status information in client

### DIFF
--- a/ninjam/qtclient/ClientRunThread.cpp
+++ b/ninjam/qtclient/ClientRunThread.cpp
@@ -30,7 +30,12 @@ ClientRunThread::ClientRunThread(QMutex *mutex, NJClient *client, QObject *paren
 void ClientRunThread::run()
 {
   mutex->lock();
+
+  // Values that we watch for changes
   int lastStatus = client->GetStatus();
+  int lastBpm = 0;
+  int lastBpi = 0;
+
   running = true;
   while (running) {
     while (!client->Run());
@@ -43,6 +48,14 @@ void ClientRunThread::run()
     if (status != lastStatus) {
       emit statusChanged(status);
       lastStatus = status;
+    }
+
+    int bpm = client->GetActualBPM();
+    int bpi = client->GetBPI();
+    if (bpm != lastBpm || bpi != lastBpi) {
+      emit beatInfoChanged(bpm, bpi);
+      lastBpm = bpm;
+      lastBpi = bpi;
     }
 
     cond.wait(mutex, 20 /* milliseconds */);

--- a/ninjam/qtclient/ClientRunThread.h
+++ b/ninjam/qtclient/ClientRunThread.h
@@ -46,6 +46,7 @@ signals:
   void chatMessageCallback(char **parms, int nparms);
   void userInfoChanged();
   void statusChanged(int newStatus);
+  void beatInfoChanged(int bpm, int bpi);
 
 private:
   bool running;

--- a/ninjam/qtclient/MainWindow.cpp
+++ b/ninjam/qtclient/MainWindow.cpp
@@ -22,6 +22,7 @@
 #include <QSplitter>
 #include <QMenuBar>
 #include <QMenu>
+#include <QStatusBar>
 #include <QSettings>
 #include <QDateTime>
 #include <QDir>
@@ -98,6 +99,8 @@ MainWindow::MainWindow(QWidget *parent)
   fileMenu->addAction(audioConfigAction);
   fileMenu->addAction(exitAction);
 
+  setupStatusBar();
+
   setWindowTitle(tr("Wahjam"));
 
   chatOutput = new QTextEdit(this);
@@ -157,6 +160,10 @@ MainWindow::MainWindow(QWidget *parent)
   connect(runThread, SIGNAL(statusChanged(int)),
           this, SLOT(ClientStatusChanged(int)));
 
+  /* Hook up an inter-thread signal for bpm/bpi changes */
+  connect(runThread, SIGNAL(beatInfoChanged(int, int)),
+          this, SLOT(BeatInfoChanged(int, int)));
+
   runThread->start();
 }
 
@@ -183,6 +190,17 @@ void MainWindow::setupChannelTree()
 
     channelTree->addLocalChannel(ch, QString::fromUtf8(name), mute, broadcast);
   }
+}
+
+void MainWindow::setupStatusBar()
+{
+  bpmLabel = new QLabel(this);
+  bpmLabel->setFrameStyle(QFrame::Panel | QFrame::Sunken);
+  statusBar()->addPermanentWidget(bpmLabel);
+
+  bpiLabel = new QLabel(this);
+  bpiLabel->setFrameStyle(QFrame::Panel | QFrame::Sunken);
+  statusBar()->addPermanentWidget(bpiLabel);
 }
 
 void MainWindow::Connect(const QString &host, const QString &user, const QString &pass)
@@ -398,6 +416,21 @@ void MainWindow::ClientStatusChanged(int newStatus)
 
   if (newStatus < 0) {
     Disconnect();
+  }
+}
+
+void MainWindow::BeatInfoChanged(int bpm, int bpi)
+{
+  if (bpm > 0) {
+    bpmLabel->setText(tr("BPM: %1").arg(bpm));
+  } else {
+    bpmLabel->setText(tr("BPM: N/A"));
+  }
+
+  if (bpi > 0) {
+    bpiLabel->setText(tr("BPI: %1").arg(bpi));
+  } else {
+    bpiLabel->setText(tr("BPI: N/A"));
   }
 }
 

--- a/ninjam/qtclient/MainWindow.h
+++ b/ninjam/qtclient/MainWindow.h
@@ -23,6 +23,7 @@
 #include <QWidget>
 #include <QTextEdit>
 #include <QLineEdit>
+#include <QLabel>
 #include <QMutex>
 #include <QAction>
 
@@ -55,6 +56,7 @@ private slots:
   void ChatInputReturnPressed();
   void UserInfoChanged();
   void ClientStatusChanged(int newStatus);
+  void BeatInfoChanged(int bpm, int bpi);
   void MetronomeMuteChanged(bool mute);
   void MetronomeBoostChanged(bool boost);
   void LocalChannelMuteChanged(int ch, bool mute);
@@ -75,8 +77,11 @@ private:
   QAction *connectAction;
   QAction *disconnectAction;
   QAction *audioConfigAction;
+  QLabel *bpmLabel;
+  QLabel *bpiLabel;
 
   void setupChannelTree();
+  void setupStatusBar();
   bool setupWorkDir();
   void cleanupWorkDir(const QString &path);
   void OnSamples(float **inbuf, int innch, float **outbuf, int outnch, int len, int srate);


### PR DESCRIPTION
This series improves the user experience by making status information about the current session visible in the GUI:
- Show error messages in the chat box when authentication fails or we are disconnected
- Show hostname in the title bar while connected
- Show BPM/BPI in the status bar
