### PR TITLE
Fix host selection from server browser

### DIFF
--- a/ninjam/qtclient/ConnectDialog.cpp
+++ b/ninjam/qtclient/ConnectDialog.cpp
@@ -80,7 +80,7 @@ QString ConnectDialog::host() const
 
 void ConnectDialog::setHost(const QString &host)
 {
-  userEdit->setText(host);
+  hostEdit->setEditText(host);
 }
 
 QString ConnectDialog::user() const


### PR DESCRIPTION
The server browser is incorrectly hooked up to place the server into the
username field.  Instead we should set the host field.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
