### PR TITLE
Vote menu and +1 link

### DIFF
--- a/ninjam/qtclient/MainWindow.h
+++ b/ninjam/qtclient/MainWindow.h
@@ -26,6 +26,7 @@
 #include <QLabel>
 #include <QMutex>
 #include <QAction>
+#include <QUrl>
 
 #include "ChannelTreeWidget.h"
 #include "MetronomeBar.h"
@@ -58,6 +59,7 @@ private slots:
   void LicenseCallback(const char *licensetext, bool *result);
   void ChatMessageCallback(char **parms, int nparms);
   void ChatInputReturnPressed();
+  void ChatLinkClicked(const QUrl &url);
   void UserInfoChanged();
   void ClientStatusChanged(int newStatus);
   void BeatsPerIntervalChanged(int bpm);


### PR DESCRIPTION
This patch series adds two features, both helps users to send !vote command without type it.
- Vote BPM/BPI menu
- +1 vote link

---
## Implementation notes
### API for send message

I wanted to send MSG to server,
but I did not want to the re-write or copy the same code from ChatInputReturnPressed.
so I just called the ChatInputReturnPressed() slot.

 TODO: separate common code to send message public method/slot for that common use.
 # In Qt, that should be implemented as slot, because I may want to call it from external script.
### insertText can break text struct.

append() will add text on the End, it was ok.
but insertText() looks assume the cursor position was the End.
every time before insertText should ensure the cursor position.

current code is working correctly, but I wrote "can break" mean when develop new codes
the insertText() without ensure the position may be that trouble.
the text cursor position is implicit state, this code is now weak for changes.

I just note here, others may meet the same problem.
but not fix it in this patch, this also can be separate task.
provide safe append for chatOutput (like chatAddLine method) may help.
### hard coding parse server's message
- It parses server message [voting-system] to add +1 link, this may not work for translated message.
  - NINJAM server code did not support i18n.
  - I don't know any public server which has translated those information message.

For now, I just hard coded it.
Ideally, voting-system (client/server side both) should be an extension.

---
## User interface and the accessibility behavior
### +1 link is modern UI ?

I did not research about that.
It is looks popular now, used in facebook,google+, and text based forum,mailing-list.
Not sure as universal designed. users who had not see the community culture  may not understand
what +1 is for. But, at least it is easier than !vote command.
### Known issues

There are several limitations now:
- When you had lead the vote first, but add link for that.
  - Server message does not tell who's vote.
- When you had joined server while voting in progress, you may not able to follow it by +1.
  - Now, the +1 link is added for the first vote only.
- +1 link is still available after you already had clicked.
  - I could not find easy solution to find the position of anchor text.

Ideas are welcome :)

NOTE: There was few trade-off issues. maintenancebility of code,
and I could not find clean approach to solve those.

The member variables of MainWindow is now like a global.
If this patch will use variables like "voted_bpi" to store the previous state,
it should be capsuled by class, not add to MainWindow members.
but the scope of chat message callback is in MainWindow now.

I am thinking command-pattern dispatch with use of Qt signal/slot mechanism.
e.g) emit MSG_recieved signal, then plugin can register own message handler as the slot,
then add +1 feature can be implemented as plugin.
