### PR TITLE
Only enable Vote menu when connected

### DIFF
--- a/ninjam/qtclient/MainWindow.cpp
+++ b/ninjam/qtclient/MainWindow.cpp
@@ -171,6 +171,28 @@ MainWindow::MainWindow(QWidget *parent)
   BeatsPerIntervalChanged(0);
   BeatsPerMinuteChanged(0);
 
+  /* Connection State */
+  connectionStateMachine = new QStateMachine(this);
+  connectedState = new QState(connectionStateMachine);
+  disconnectedState = new QState(connectionStateMachine);
+
+  connectedState->assignProperty(voteMenu, "enabled", true);
+  connectedState->assignProperty(connectAction, "enabled", false);
+  connectedState->assignProperty(disconnectAction, "enabled", true);
+  connectedState->assignProperty(audioConfigAction, "enabled", false);
+  disconnectedState->assignProperty(voteMenu, "enabled", false);
+  disconnectedState->assignProperty(connectAction, "enabled", true);
+  disconnectedState->assignProperty(disconnectAction, "enabled", false);
+  disconnectedState->assignProperty(audioConfigAction, "enabled", true);
+
+  connectedState->addTransition(this, SIGNAL(Disconnected()), disconnectedState);
+  disconnectedState->addTransition(this, SIGNAL(Connected()), connectedState);
+
+  connectionStateMachine->setInitialState(disconnectedState);
+  connectionStateMachine->setErrorState(disconnectedState);
+  connectionStateMachine->start();
+
+
   runThread = new ClientRunThread(&clientMutex, &client);
 
   /* Hook up an inter-thread signal for the license agreement dialog */
@@ -263,11 +285,6 @@ void MainWindow::Connect(const QString &host, const QString &user, const QString
     exit(1);
   }
 
-  audioConfigAction->setEnabled(false);
-  connectAction->setEnabled(false);
-  disconnectAction->setEnabled(true);
-  voteMenu->setEnabled(true);
-
   setWindowTitle(tr("Wahjam - %1").arg(host));
 
   client.Connect(host.toAscii().data(),
@@ -294,10 +311,6 @@ void MainWindow::Disconnect()
 
   setWindowTitle(tr("Wahjam"));
 
-  audioConfigAction->setEnabled(true);
-  connectAction->setEnabled(true);
-  disconnectAction->setEnabled(false);
-  voteMenu->setEnabled(false);
   BeatsPerMinuteChanged(0);
   BeatsPerIntervalChanged(0);
   emit Disconnected();
@@ -461,6 +474,7 @@ void MainWindow::ClientStatusChanged(int newStatus)
     clientMutex.unlock();
 
     statusMessage = tr("Connected to %1 as %2").arg(host, username);
+    emit Connected();
   } else if (!errstr.isEmpty()) {
     statusMessage = "Error: " + errstr;
   } else if (newStatus == NJClient::NJC_STATUS_DISCONNECTED) {

--- a/ninjam/qtclient/MainWindow.h
+++ b/ninjam/qtclient/MainWindow.h
@@ -27,6 +27,8 @@
 #include <QMutex>
 #include <QAction>
 #include <QUrl>
+#include <QStateMachine>
+#include <QState>
 
 #include "ChannelTreeWidget.h"
 #include "MetronomeBar.h"
@@ -48,6 +50,7 @@ public:
   static MainWindow *GetInstance();
 
 signals:
+  void Connected();
   void Disconnected();
 
 public slots:
@@ -92,6 +95,9 @@ private:
   QLabel *bpmLabel;
   QLabel *bpiLabel;
   MetronomeBar *metronomeBar;
+  QStateMachine *connectionStateMachine;
+  QState *connectedState;
+  QState *disconnectedState;
 
   void setupChannelTree();
   void setupStatusBar();


### PR DESCRIPTION
Make the state of the client a little clearer by disabling the Vote menu
when disconnected from a server.  When connected to a server the Vote
menu will be enabled and available for the user.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
