### PR TITLE
Chatoutput class

### DIFF
--- a/ninjam/qtclient/ChatOutput.cpp
+++ b/ninjam/qtclient/ChatOutput.cpp
@@ -1,0 +1,157 @@
+/*
+    Copyright (C) 2012 Ikkei Shimomura (tea) <Ikkei.Shimomura@gmail.com>
+
+    Wahjam is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    Wahjam is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Wahjam; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+#include "ChatOutput.h"
+
+#ifndef AUTOLINK_REGEXP
+#define AUTOLINK_REGEXP "https?://[-_.!~*'()a-zA-Z0-9;/?:@&=+$,%#]+"
+#endif
+
+
+ChatOutput::ChatOutput(QWidget *parent)
+  : QTextBrowser(parent), autolinkRegexp(AUTOLINK_REGEXP)
+{
+  setReadOnly(true);
+  setOpenLinks(true);
+  setOpenExternalLinks(true);
+  setUndoRedoEnabled(false);
+
+  normalFormat.setFontWeight(QFont::Normal);
+
+  boldFormat.setFontWeight(QFont::Bold);
+
+  linkFormat.setAnchor(true);
+  linkFormat.setAnchorHref("");
+  linkFormat.setFontWeight(QFont::Bold);
+  linkFormat.setForeground(palette().link());
+  linkFormat.setUnderlineStyle(QTextCharFormat::SingleUnderline);
+
+  cursor = textCursor();
+
+  Q_ASSERT(autolinkRegexp.isValid());
+}
+
+void ChatOutput::addText(const QString &text, const QTextCharFormat &format)
+{
+  cursor.insertText(text, format);
+}
+
+/**
+ * add content with autolink
+ */
+void ChatOutput::addContent(const QString &content, const QTextCharFormat &format)
+{
+  QString text;
+  QString url;
+  int offset = 0;
+  int index = autolinkRegexp.indexIn(content, offset);
+
+  // avoid QString::mid call, content does not have links most cases.
+  if (index == -1) {
+    Q_ASSERT(offset == 0);
+    addText(content, format);
+    return;
+  }
+
+  do {
+    Q_ASSERT(index == -1 || index >= 0);
+
+    // add normal text.
+    // when index was -1, no more links, that add the rest of content.
+    text = content.mid(offset, (index == -1) ? -1 : (index-offset));
+    if (!text.isEmpty()) {
+      addText(text, format);
+    }
+
+    if (index == -1) {
+      break;
+    }
+
+    url = autolinkRegexp.cap(0);
+    if (!url.isEmpty()) {
+      addLink(url, url);
+    }
+
+    // set variables for next iteration.
+    offset = index + autolinkRegexp.matchedLength();
+    index = autolinkRegexp.indexIn(content, offset);
+
+    // NOTE: overflow check ((int + int) >= 0)
+    Q_ASSERT(offset >= 0);
+
+  } while (offset >= 0);
+}
+
+void ChatOutput::addLine(const QString &prefix, const QString &content)
+{
+  // Edit block for Undo/Redo.
+  cursor.beginEditBlock();
+  {
+    cursor.movePosition(QTextCursor::End);
+
+    if (!document()->isEmpty()) {
+      cursor.insertBlock();
+    }
+
+    if (!prefix.isEmpty()) {
+      addText(prefix, boldFormat);
+    }
+
+    if (!content.isEmpty()) {
+      addContent(content, normalFormat);
+    }
+  }
+  cursor.endEditBlock();
+
+  // Autoscroll bottom of chat
+  moveCursor(QTextCursor::End);
+}
+
+void ChatOutput::addLink(const QString &href, const QString &linktext)
+{
+  QTextCharFormat format = linkFormat;
+  format.setAnchorHref(href);
+
+  addText(linktext, format);
+}
+
+void ChatOutput::addMessage(const QString &src, const QString &message)
+{
+  addLine(tr("<%1> ").arg(src), message);
+}
+
+void ChatOutput::addActionMessage(const QString &src, const QString &message)
+{
+  addLine(tr("* %1 ").arg(src), message);
+}
+
+void ChatOutput::addPrivateMessage(const QString &src, const QString &message)
+{
+  addLine(tr("* %1 ").arg(src), message);
+}
+
+void ChatOutput::addInfoMessage(const QString &message)
+{
+  addLine(tr("[INFO] "), message);
+}
+
+void ChatOutput::addErrorMessage(const QString &message)
+{
+  addLine(tr("[ERROR] "), message);
+}
+

--- a/ninjam/qtclient/ChatOutput.h
+++ b/ninjam/qtclient/ChatOutput.h
@@ -1,0 +1,55 @@
+/*
+    Copyright (C) 2012 Ikkei Shimomura (tea) <Ikkei.Shimomura@gmail.com>
+
+    Wahjam is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    Wahjam is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Wahjam; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+#ifndef _CHATOUTPUT_H_
+#define _CHATOUTPUT_H_
+
+#include <QRegExp>
+#include <QTextBrowser>
+
+
+class ChatOutput : public QTextBrowser
+{
+  Q_OBJECT
+
+public:
+  ChatOutput(QWidget *parent=0);
+
+public slots:
+  void addText(const QString &text, const QTextCharFormat &format);
+  void addContent(const QString &content, const QTextCharFormat &format);
+  void addLine(const QString &prefix, const QString &content);
+  void addLink(const QString &href, const QString &linktext);
+
+  void addMessage(const QString &src, const QString &message);
+  void addActionMessage(const QString &src, const QString &message);
+  void addPrivateMessage(const QString &src, const QString &message);
+  void addInfoMessage(const QString &message);
+  void addErrorMessage(const QString &message);
+
+private:
+  QRegExp autolinkRegexp;
+  QTextCharFormat normalFormat;
+  QTextCharFormat boldFormat;
+  QTextCharFormat linkFormat;
+  QTextCursor cursor;
+
+};
+
+#endif /* _CHATOUTPUT_H_ */
+

--- a/ninjam/qtclient/MainWindow.h
+++ b/ninjam/qtclient/MainWindow.h
@@ -21,7 +21,6 @@
 
 #include <QMainWindow>
 #include <QWidget>
-#include <QTextBrowser>
 #include <QLineEdit>
 #include <QLabel>
 #include <QMutex>
@@ -30,6 +29,7 @@
 
 #include "ChannelTreeWidget.h"
 #include "MetronomeBar.h"
+#include "ChatOutput.h"
 #include "../njclient.h"
 #include "../audiostream.h"
 
@@ -82,7 +82,7 @@ private:
   audioStreamer *audio;
   QMutex clientMutex;
   ClientRunThread *runThread;
-  QTextBrowser *chatOutput;
+  ChatOutput *chatOutput;
   QLineEdit *chatInput;
   ChannelTreeWidget *channelTree;
   QAction *connectAction;

--- a/ninjam/qtclient/ServerBrowser.cpp
+++ b/ninjam/qtclient/ServerBrowser.cpp
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2012 tea <Ikkei.Shimomura@gmail.com>
+    Copyright (C) 2012 Ikkei Shimomura (tea) <Ikkei.Shimomura@gmail.com>
 
     Wahjam is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/ninjam/qtclient/ServerBrowser.h
+++ b/ninjam/qtclient/ServerBrowser.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2012 tea <Ikkei.Shimomura@gmail.com>
+    Copyright (C) 2012 Ikkei Shimomura (tea) <Ikkei.Shimomura@gmail.com>
 
     Wahjam is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/ninjam/qtclient/qtclient.pro
+++ b/ninjam/qtclient/qtclient.pro
@@ -29,6 +29,7 @@ HEADERS += ChannelTreeWidget.h
 HEADERS += PortAudioConfigDialog.h
 HEADERS += ServerBrowser.h
 HEADERS += MetronomeBar.h
+HEADERS += ChatOutput.h
 
 SOURCES += qtclient.cpp
 SOURCES += MainWindow.cpp
@@ -38,6 +39,7 @@ SOURCES += ChannelTreeWidget.cpp
 SOURCES += PortAudioConfigDialog.cpp
 SOURCES += ServerBrowser.cpp
 SOURCES += MetronomeBar.cpp
+SOURCES += ChatOutput.cpp
 SOURCES += ../../WDL/jnetlib/asyncdns.cpp
 SOURCES += ../../WDL/jnetlib/connection.cpp
 SOURCES += ../../WDL/jnetlib/listen.cpp


### PR DESCRIPTION
This patch implements #43
Summary of changes
- separate application specific code and component.
- use "tr" for translation messages
- separate add message slots for message types.
- reuse QTextCharFormat/QTextCursor as member.
- URL auto-link

---
## Implementation notes
### Why those methods are slot

as QTextEdit#append is public slot, and it is an easy way to be callable from qtscript.
### Why so many add messages slots

Currently, ChatOutput is missing save information that sender, what type of messages, ...
The view shows it with format but that will be lost when saved as plain text.
So it was the prepare step to make message handlers in future. (like model-view for message log)
### parse url for autolink

I tried to do that by QSyntaxHighlighter, but QTextCharFormat#setAnchor in syntax-highlighter did not work.
The highlight url was worked, but that did not be clickable.

---
## I did not do in this patch

notes for future todo.
- API design, not frozen yet. some of slots may possible to be private or inline.
- Scalability of message log data (no max-lines, or no limit of data size) when log become too much?
- Extendability of parser for auto-link. its ad-hoc parser, need to be another approach when extend it.
