### PR TITLE
Fix WDL_SHA1 word size on 64-bit machines

### DIFF
--- a/WDL/sha.cpp
+++ b/WDL/sha.cpp
@@ -64,7 +64,7 @@ void WDL_SHA1::reset()
   H[2] = 0x98badcfeL;
   H[3] = 0x10325476L;
   H[4] = 0xc3d2e1f0L;
-  int x;
+  unsigned int x;
   for (x = 0; x < sizeof(W)/sizeof(W[0]); x ++) W[x]=0;
 }
 
@@ -78,38 +78,38 @@ void WDL_SHA1::add(const void *data, int datalen)
   for (i = 0; i < datalen; i++) 
   {
     W[lenW / 4] <<= 8;
-    W[lenW / 4] |= (unsigned long)((const unsigned char *)data)[i];
+    W[lenW / 4] |= (uint32_t)((const unsigned char *)data)[i];
     if (!(++lenW & 63)) 
     {
       int t;
 
-      unsigned long A = H[0];
-      unsigned long B = H[1];
-      unsigned long C = H[2];
-      unsigned long D = H[3];
-      unsigned long E = H[4];
+      uint32_t A = H[0];
+      uint32_t B = H[1];
+      uint32_t C = H[2];
+      uint32_t D = H[3];
+      uint32_t E = H[4];
 
 
       for (t = 16; t < 80; t++) W[t] = SHA_ROTL(W[t-3] ^ W[t-8] ^ W[t-14] ^ W[t-16], 1);
 
       for (t = 0; t < 20; t++) 
       {
-        unsigned long TEMP = SHA_ROTL(A,5) + E + W[t] + 0x5a827999L + (((C^D)&B)^D);
+        uint32_t TEMP = SHA_ROTL(A,5) + E + W[t] + 0x5a827999L + (((C^D)&B)^D);
         SHUFFLE();
       }
       for (; t < 40; t++) 
       {
-        unsigned long TEMP = SHA_ROTL(A,5) + E + W[t] + 0x6ed9eba1L + (B^C^D);
+        uint32_t TEMP = SHA_ROTL(A,5) + E + W[t] + 0x6ed9eba1L + (B^C^D);
         SHUFFLE();
       }
       for (; t < 60; t++) 
       {
-        unsigned long TEMP = SHA_ROTL(A,5) + E + W[t] + 0x8f1bbcdcL + ((B&C)|(D&(B|C)));
+        uint32_t TEMP = SHA_ROTL(A,5) + E + W[t] + 0x8f1bbcdcL + ((B&C)|(D&(B|C)));
         SHUFFLE();
       }
       for (; t < 80; t++) 
       {
-        unsigned long TEMP = SHA_ROTL(A,5) + E + W[t] + 0xca62c1d6L + (B^C^D);
+        uint32_t TEMP = SHA_ROTL(A,5) + E + W[t] + 0xca62c1d6L + (B^C^D);
         SHUFFLE();
       }
 

--- a/WDL/sha.h
+++ b/WDL/sha.h
@@ -48,6 +48,7 @@
 #ifndef _WDL_SHA_H_
 #define _WDL_SHA_H_
 
+#include <stdint.h>
 
 #define WDL_SHA1SIZE 20
 
@@ -63,10 +64,10 @@ public:
 
 private:
 
-  unsigned long H[5];
-  unsigned long W[80];
+  uint32_t H[5];
+  uint32_t W[80];
   int lenW;
-  unsigned long size[2];
+  uint32_t size[2];
 };
 
 #endif


### PR DESCRIPTION
RFC 3174 "US Secure Hash Algorithm 1 (SHA1)" defines the SHA1 algorithm
in terms of 32-bit words.  WDL_SHA1 is not portable to 64-bit
architectures because it uses unsigned long when it should really use
uint32_t.

Switch to uint32_t and also fix a signed/unsigned integer comparison
warning.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
