### PR TITLE
Make QNetworkAccessManager global

### DIFF
--- a/ninjam/qtclient/ConnectDialog.cpp
+++ b/ninjam/qtclient/ConnectDialog.cpp
@@ -22,10 +22,10 @@
 
 #include "ConnectDialog.h"
 
-ConnectDialog::ConnectDialog(QWidget *parent)
+ConnectDialog::ConnectDialog(QNetworkAccessManager *netManager, QWidget *parent)
   : QDialog(parent)
 {
-  serverBrowser = new ServerBrowser(this);
+  serverBrowser = new ServerBrowser(netManager, this);
   connect(serverBrowser, SIGNAL(serverItemClicked(const QString &)),
           this, SLOT(setHost(const QString &)));
   connect(serverBrowser, SIGNAL(serverItemActivated(const QString &)),

--- a/ninjam/qtclient/ConnectDialog.h
+++ b/ninjam/qtclient/ConnectDialog.h
@@ -23,6 +23,7 @@
 #include <QLineEdit>
 #include <QCheckBox>
 #include <QComboBox>
+#include <QNetworkAccessManager>
 #include "ServerBrowser.h"
 
 class ConnectDialog : public QDialog
@@ -34,7 +35,7 @@ class ConnectDialog : public QDialog
   Q_PROPERTY(QString pass READ pass)
 
 public:
-  ConnectDialog(QWidget *parent = 0);
+  ConnectDialog(QNetworkAccessManager *netManager, QWidget *parent = 0);
   QString host() const;
   QString user() const;
   bool isPublicServer() const;

--- a/ninjam/qtclient/MainWindow.cpp
+++ b/ninjam/qtclient/MainWindow.cpp
@@ -79,6 +79,8 @@ MainWindow::MainWindow(QWidget *parent)
   client.SetLocalChannelInfo(0, "channel0", true, 0, false, 0, true, true);
   client.SetLocalChannelMonitoring(0, false, 0.0f, false, 0.0f, false, false, false, false);
 
+  netManager = new QNetworkAccessManager(this);
+
   connectAction = new QAction(tr("&Connect..."), this);
   connect(connectAction, SIGNAL(triggered()), this, SLOT(ShowConnectDialog()));
 
@@ -356,7 +358,7 @@ void MainWindow::cleanupWorkDir(const QString &path)
 void MainWindow::ShowConnectDialog()
 {
   const QUrl url("http://autosong.ninjam.com/serverlist.php");
-  ConnectDialog connectDialog;
+  ConnectDialog connectDialog(netManager);
   QStringList hosts = settings->value("connect/hosts").toStringList();
 
   connectDialog.resize(600, 500);

--- a/ninjam/qtclient/MainWindow.h
+++ b/ninjam/qtclient/MainWindow.h
@@ -28,6 +28,7 @@
 #include <QUrl>
 #include <QStateMachine>
 #include <QState>
+#include <QNetworkAccessManager>
 
 #include "qtclient.h"
 #include "ChannelTreeWidget.h"
@@ -85,6 +86,7 @@ private:
   NJClient client;
   audioStreamer *audio;
   QMutex clientMutex;
+  QNetworkAccessManager *netManager;
   ClientRunThread *runThread;
   ChatOutput *chatOutput;
   QLineEdit *chatInput;

--- a/ninjam/qtclient/ServerBrowser.cpp
+++ b/ninjam/qtclient/ServerBrowser.cpp
@@ -23,23 +23,13 @@
 /**
  * ServerBrowser constructor
  */
-ServerBrowser::ServerBrowser(QWidget *parent)
-  : QTreeWidget(parent)
+ServerBrowser::ServerBrowser(QNetworkAccessManager *manager_, QWidget *parent)
+  : QTreeWidget(parent), netManager(manager_)
 {
   setHeaderLabels(QStringList() << "Server" << "Tempo" << "Users");
   setRootIsDecorated(false);
   setItemsExpandable(false);
   setColumnWidth(0, 200);
-
-
-  // NOTE: network-access-manager should be application global (singleton).
-  // but currently, we don't use QtNetwork other place, so it just stays here.
-
-  // NOTE: when the network-access-manager move scope, be careful the life
-  // cycle of reply object. it should be deleted by manual.
-
-  manager = new QNetworkAccessManager(this);
-
 
   connect(this, SIGNAL(itemClicked(QTreeWidgetItem*,int)),
           this, SLOT(onItemClicked(QTreeWidgetItem*,int)));
@@ -51,7 +41,7 @@ void ServerBrowser::loadServerList(const QUrl &url)
 {
   QNetworkRequest request(url);
 
-  reply = manager->get(request);
+  reply = netManager->get(request);
 
   connect(reply, SIGNAL(finished()),
           this, SLOT(completeDownloadServerList()));

--- a/ninjam/qtclient/ServerBrowser.h
+++ b/ninjam/qtclient/ServerBrowser.h
@@ -37,7 +37,7 @@ class ServerBrowser : public QTreeWidget
   Q_OBJECT
 
 public:
-  ServerBrowser(QWidget *parent=0);
+  ServerBrowser(QNetworkAccessManager *manager_, QWidget *parent=0);
   void loadServerList(const QUrl &url);
   void parseServerList(QTextStream *stream);
 
@@ -51,7 +51,7 @@ private slots:
   void onItemActivated(QTreeWidgetItem *item, int column);
 
 private:
-  QNetworkAccessManager *manager;
+  QNetworkAccessManager *netManager;
   QNetworkReply *reply;
 };
 


### PR DESCRIPTION
The ServerBrowser uses QNetworkAccessManager for HTTP requests.
Normally an application uses a single QNetworkAccessManager instance so
that cookies and other state are shared.

This patch moves QNetworkAccessManager out of ServerBrowser and gives it
a global variable that is initialized in main().

The ConnectDialog and ServerBrowser constructors need to take the
QNetworkAccessManager as an argument.  They do not take advantage of the
global so to keep the classes decoupled and easily reusable.

Note that the comment in ServerBrowser about deleting reply objects is
outdated - we already connect the finish() signal to
reply->deleteLater().  It is safe to drop the comment, the reply object
will be freed.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
