### PR TITLE
Flush Net_Connection socket before close()

### DIFF
--- a/ninjam/netmsg.cpp
+++ b/ninjam/netmsg.cpp
@@ -208,5 +208,6 @@ Net_Connection::~Net_Connection()
 
 void Net_Connection::Kill()
 {
+  m_sock->flush(); /* try to send any queued data before closing */
   m_sock->close();
 }


### PR DESCRIPTION
Data written to QTcpSocket is not sent immediately so that several small
writes can generate a single TCP packet on the wire instead of many
small packets.  This is normally no problem since the data will be
sent automatically later, from the event loop.

When a QTcpSocket is closed we need to call flush() to try sending any
remaining data.  This turns out to be important for the status user in
Wahjam because the server enqueues several packets and then closes the
connection to the client.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
