### PR TITLE
Make wahjamsrv a console application under Windows

### DIFF
--- a/ninjam/server/wahjamsrv.pro
+++ b/ninjam/server/wahjamsrv.pro
@@ -12,6 +12,9 @@ QT += network
 # Core ninjam/ code does not use wide characters
 win32:DEFINES -= UNICODE
 
+# Build console application
+win32:CONFIG += console
+
 # Input
 HEADERS += usercon.h \
            Server.h \


### PR DESCRIPTION
The server has no GUI and therefore should be built as a console
application under Windows.  This links in the appropriate libraries and
makes console API functions available, which may be useful in the
future.

Reported-by: Ikkei Shimomura (tea) Ikkei.Shimomura@gmail.com
Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
