### PR TITLE
Switch from unlink(2) to remove(3) in njclient.cpp

### DIFF
--- a/ninjam/njclient.cpp
+++ b/ninjam/njclient.cpp
@@ -66,7 +66,7 @@ class DecodeState
 #ifdef _WIN32
         DeleteFile(delete_on_delete.Get());
 #else
-        unlink(delete_on_delete.Get());
+        remove(delete_on_delete.Get());
 #endif
       }
     }


### PR DESCRIPTION
The build fails on non-Windows platforms due to a unlink(2) call in
njclient.cpp without including unistd.h.  It is not clear why this build
failure never appeared before but it was introduced in commit
71503ffdde2cd15f835f2acc968ce65105a27774 "Replace JNL_Connection with
QTcpSocket" when the jnetlib header was no longer included.

Since njclient.cpp already includes stdio.h, use the standard C
remove(3) function instead of POSIX unlink(2).  This way we avoid more
platform-specific #ifdefs.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
