### PR TITLE
Add missing unistd.h includes to wahjamsrv

### DIFF
--- a/ninjam/server/SignalHandler.cpp
+++ b/ninjam/server/SignalHandler.cpp
@@ -16,6 +16,7 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+#include <unistd.h>
 #include <errno.h>
 #include <signal.h>
 #include <sys/types.h>

--- a/ninjam/server/ninjamsrv.cpp
+++ b/ninjam/server/ninjamsrv.cpp
@@ -34,6 +34,7 @@
 #else
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #endif
 #include <time.h>
 #include <stdarg.h>


### PR DESCRIPTION
A recent glibc update exposed missing header includes and the wahjamsrv
build is now failing.  The fix is easy: include unistd.h in the
appropriate files for POSIX hosts.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
