### PR TITLE
Remove "Boost (+3dB)" checkbox

### DIFF
--- a/ninjam/qtclient/ChannelTreeWidget.cpp
+++ b/ninjam/qtclient/ChannelTreeWidget.cpp
@@ -33,13 +33,13 @@ enum
 ChannelTreeWidget::ChannelTreeWidget(QWidget *parent)
   : QTreeWidget(parent)
 {
-  setHeaderLabels(QStringList("Name") << "Mute" << "Broadcast" << "Boost (+3dB)");
+  setHeaderLabels(QStringList("Name") << "Mute" << "Broadcast");
   setRootIsDecorated(false);
   setItemsExpandable(false);
   setSelectionMode(QAbstractItemView::NoSelection);
 
   QTreeWidgetItem *local = addRootItem("Local");
-  QTreeWidgetItem *metronome = addChannelItem(local, "Metronome", CF_BOOST);
+  QTreeWidgetItem *metronome = addChannelItem(local, "Metronome", 0);
   metronome->setData(0, ItemTypeRole, ItemTypeMetronome);
 
   connect(this, SIGNAL(itemChanged(QTreeWidgetItem*, int)),
@@ -63,16 +63,13 @@ QTreeWidgetItem *ChannelTreeWidget::addChannelItem(QTreeWidgetItem *parent, cons
   if (flags & CF_BROADCAST) {
     channel->setCheckState(2, Qt::Unchecked);
   }
-  if (flags & CF_BOOST) {
-    channel->setCheckState(3, Qt::Unchecked);
-  }
   return channel;
 }
 
 void ChannelTreeWidget::addLocalChannel(int ch, const QString &name, bool mute, bool broadcast)
 {
   QTreeWidgetItem *local = topLevelItem(0);
-  QTreeWidgetItem *channel = addChannelItem(local, name, CF_BROADCAST | CF_BOOST);
+  QTreeWidgetItem *channel = addChannelItem(local, name, CF_BROADCAST);
 
   channel->setData(0, ItemTypeRole, ItemTypeLocalChannel);
   channel->setData(0, ChannelIndexRole, ch);
@@ -92,8 +89,6 @@ void ChannelTreeWidget::handleItemChanged(QTreeWidgetItem *item, int column)
   case ItemTypeMetronome:
     if (column == 1) {
       emit MetronomeMuteChanged(state);
-    } else if (column == 3) {
-      emit MetronomeBoostChanged(state);
     }
     break;
   case ItemTypeLocalChannel:
@@ -103,8 +98,6 @@ void ChannelTreeWidget::handleItemChanged(QTreeWidgetItem *item, int column)
       emit LocalChannelMuteChanged(ch, state);
     } else if (column == 2) {
       emit LocalChannelBroadcastChanged(ch, state);
-    } else if (column == 3) {
-      emit LocalChannelBoostChanged(ch, state);
     }
     break;
   }

--- a/ninjam/qtclient/ChannelTreeWidget.h
+++ b/ninjam/qtclient/ChannelTreeWidget.h
@@ -57,9 +57,7 @@ public:
 
 signals:
   void MetronomeMuteChanged(bool mute);
-  void MetronomeBoostChanged(bool boost);
   void LocalChannelMuteChanged(int ch, bool mute);
-  void LocalChannelBoostChanged(int ch, bool boost);
   void LocalChannelBroadcastChanged(int ch, bool broadcast);
   void RemoteChannelMuteChanged(int useridx, int channelidx, bool mute);
 
@@ -69,7 +67,6 @@ private slots:
 private:
   enum ChannelFlags {
     CF_BROADCAST = 0x1,
-    CF_BOOST     = 0x2,
   };
 
   QTreeWidgetItem *addRootItem(const QString &text);

--- a/ninjam/qtclient/MainWindow.cpp
+++ b/ninjam/qtclient/MainWindow.cpp
@@ -129,12 +129,8 @@ MainWindow::MainWindow(QWidget *parent)
   setupChannelTree();
   connect(channelTree, SIGNAL(MetronomeMuteChanged(bool)),
           this, SLOT(MetronomeMuteChanged(bool)));
-  connect(channelTree, SIGNAL(MetronomeBoostChanged(bool)),
-          this, SLOT(MetronomeBoostChanged(bool)));
   connect(channelTree, SIGNAL(LocalChannelMuteChanged(int, bool)),
           this, SLOT(LocalChannelMuteChanged(int, bool)));
-  connect(channelTree, SIGNAL(LocalChannelBoostChanged(int, bool)),
-          this, SLOT(LocalChannelBoostChanged(int, bool)));
   connect(channelTree, SIGNAL(LocalChannelBroadcastChanged(int, bool)),
           this, SLOT(LocalChannelBroadcastChanged(int, bool)));
   connect(channelTree, SIGNAL(RemoteChannelMuteChanged(int, int, bool)),
@@ -595,20 +591,9 @@ void MainWindow::MetronomeMuteChanged(bool mute)
   client.config_metronome_mute = mute;
 }
 
-void MainWindow::MetronomeBoostChanged(bool boost)
-{
-  client.config_metronome = boost ? DB2VAL(3) : DB2VAL(0);
-}
-
 void MainWindow::LocalChannelMuteChanged(int ch, bool mute)
 {
   client.SetLocalChannelMonitoring(ch, false, 0, false, 0, true, mute, false, false);
-}
-
-void MainWindow::LocalChannelBoostChanged(int ch, bool boost)
-{
-  client.SetLocalChannelMonitoring(ch, true, boost ? DB2VAL(3) : DB2VAL(0),
-                                   false, 0, false, false, false, false);
 }
 
 void MainWindow::LocalChannelBroadcastChanged(int ch, bool broadcast)

--- a/ninjam/qtclient/MainWindow.h
+++ b/ninjam/qtclient/MainWindow.h
@@ -67,9 +67,7 @@ private slots:
   void BeatsPerIntervalChanged(int bpm);
   void BeatsPerMinuteChanged(int bpi);
   void MetronomeMuteChanged(bool mute);
-  void MetronomeBoostChanged(bool boost);
   void LocalChannelMuteChanged(int ch, bool mute);
-  void LocalChannelBoostChanged(int ch, bool boost);
   void LocalChannelBroadcastChanged(int ch, bool broadcast);
   void RemoteChannelMuteChanged(int useridx, int channelidx, bool mute);
   void ShowAboutDialog();


### PR DESCRIPTION
The "Boost (+3dB)" feature increases the playback volume of the
metronome or local channel.  The idea was to help the metronome or
user's instrument cut through the mix.

This patch removes the feature because it is rarely used and can confuse
users who believe it increases their remote volume.  Only the local
playback volume is increased, remote users do not hear louder volume.

Instead of manipulating local volume, jams work best when each user
tries to fit into the mix.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
