### PR TITLE
Fix "Mute" checkbox

### DIFF
--- a/ninjam/qtclient/ChannelTreeWidget.cpp
+++ b/ninjam/qtclient/ChannelTreeWidget.cpp
@@ -147,10 +147,10 @@ void ChannelTreeWidget::RemoteChannelUpdater::addChannel(int channelidx, const Q
     channel->setText(0, name);
   } else {
     channel = owner->addChannelItem(user, name, 0);
-    channel->setData(0, ItemTypeRole, ItemTypeRemoteChannel);
-    channel->setData(0, UserIndexRole, useridx);
   }
 
+  channel->setData(0, ItemTypeRole, ItemTypeRemoteChannel);
+  channel->setData(0, UserIndexRole, useridx);
   channel->setData(0, ChannelIndexRole, channelidx);
   channel->setCheckState(1, mute ? Qt::Checked : Qt::Unchecked);
 }


### PR DESCRIPTION
The ChannelTreeWidget has a bug where user indices are not updated when
users leave or join the server.  Make sure to store the user index so
the mute checkbox mutes the correct user!

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
