### PR TITLE
Remove audio buffer files

### DIFF
--- a/ninjam/qtclient/MainWindow.cpp
+++ b/ninjam/qtclient/MainWindow.cpp
@@ -70,7 +70,7 @@ MainWindow::MainWindow(QWidget *parent)
   }
   MainWindow::instance = this;
 
-  client.config_savelocalaudio = 0;
+  client.config_savelocalaudio = -1;
   client.LicenseAgreementCallback = LicenseCallbackTrampoline;
   client.ChatMessage_Callback = ChatMessageCallbackTrampoline;
   client.SetLocalChannelInfo(0, "channel0", true, 0, false, 0, true, true);
@@ -264,11 +264,13 @@ void MainWindow::Disconnect()
 
   client.Disconnect();
   QString workDirPath = QString::fromUtf8(client.GetWorkDir());
-  bool keepWorkDir = client.config_savelocalaudio;
+  bool keepWorkDir = client.config_savelocalaudio != -1;
   client.SetWorkDir(NULL);
 
-  if (!workDirPath.isEmpty() && !keepWorkDir) {
-    cleanupWorkDir(workDirPath);
+  if (!workDirPath.isEmpty()) {
+    if (!keepWorkDir) {
+      cleanupWorkDir(workDirPath);
+    }
     chatOutput->addInfoMessage(tr("Disconnected"));
   }
 


### PR DESCRIPTION
Let NJClient delete temporary .ogg files.  It is useful to keep them
around for debugging or post-jam mixing.  For now it's most
user-friendly to delete them so we don't silently fill up the user's
harddisk.  In the future we may introduce a setting where the user can
keep jams saved.

Also fix the logic of printing a "Disconnected" message.  It should not
depend on whether or not to delete the session directory.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
