### PR TITLE
Use pkg-config for qtclient

### DIFF
--- a/ninjam/qtclient/qtclient.pro
+++ b/ninjam/qtclient/qtclient.pro
@@ -14,8 +14,8 @@ INCLUDEPATH += .
 QT += network
 
 QMAKE_CXXFLAGS += -Wno-write-strings
-LIBS += -lm -lvorbisenc -lvorbis -logg
-LIBS += -lportaudio
+CONFIG += link_pkgconfig
+PKGCONFIG += vorbis vorbisenc portaudio-2.0
 
 # Core ninjam/ code does not use wide characters
 win32:DEFINES -= UNICODE


### PR DESCRIPTION
These patches switch from hardcoded LIBS to pkg-config(1).  This change will allow the build to work across different hosts because LIBS can be different (even for the same library dependency).

The real benefit of this change is that we can finally build Wahjam for Windows with WDM Kernel Streaming audio support!

Anyone wishing to build without pkg-config(1) needs to locally modify/override the qtclient.pro file's LIBS.
