### PR TITLE
Rename "qtclient" binary to "wahjam"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ moc_*.cpp
 ninjam/server/wahjamsrv
 ninjam/server/Makefile
 ninjam/qtclient/Makefile
-ninjam/qtclient/qtclient
+ninjam/qtclient/wahjam

--- a/ninjam/qtclient/qtclient.pro
+++ b/ninjam/qtclient/qtclient.pro
@@ -8,7 +8,7 @@ DEFINES += VERSION=\'\"$$VERSION\"\'
 DEFINES += COMMIT_ID=\'\"$$system(git rev-parse HEAD)\"\'
 
 TEMPLATE = app
-TARGET = 
+TARGET = wahjam
 DEPENDPATH += .
 INCLUDEPATH += .
 QT += network


### PR DESCRIPTION
Support for the legacy clients (curses, Windows, Mac OS X) has been gone
for a while.  The only client is the cross-platform Qt client.  Call the
binary "wahjam" so packaging scripts don't need to duplicate this step
after the binary has been built.

Note we still use the qtclient.pro project file.  Eventually we should
move to a global project file for wahjam, wahjamsrv, and other build
targets.  In the meantime there is no need to rename the project file.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
