### PR TITLE
Use channel index instead of iterator value in MainWindow::UserInfoChanged()

### DIFF
--- a/ninjam/qtclient/MainWindow.cpp
+++ b/ninjam/qtclient/MainWindow.cpp
@@ -391,8 +391,9 @@ void MainWindow::UserInfoChanged()
     const char *name = client.GetUserState(useridx, NULL, NULL, NULL);
     updater.addUser(useridx, QString::fromUtf8(name));
 
+    int i = 0;
     int channelidx;
-    for (channelidx = 0; client.EnumUserChannels(useridx, channelidx) != -1; channelidx++) {
+    while ((channelidx = client.EnumUserChannels(useridx, i++)) != -1) {
       bool mute;
       name = client.GetUserChannelState(useridx, channelidx, NULL, NULL, NULL, &mute, NULL);
       updater.addChannel(channelidx, QString::fromUtf8(name), mute);


### PR DESCRIPTION
The NJClient class usually deals with channel index values (from 0 to
31).  The exception is NJClient::EnumUserChannels() which iterates
sequentially over channel indices:

  /**
- Return channel index for a given user or -1 if no more channels
  *
- @useridx: remote user index
- @i:       iterator value, use 0 on first call and then increment
  */
  int MainWindow::EnumUserChannels(int useridx, int i);

Normally a user with one channel looks like this:

  User: "Bob"
    Channel index 0: "Guitar"

But the channel index is arbitrary and not required to start at 0:

  User: "Jim"
    Channel index 12: "Guitar"

MainWindow::UserInfoChanged() incorrectly used the
NJClient::EnumUserChannels() iterator value instead of the channel
index.  When there is a 1:1 mapping between channels counts and their
indices this will not be noticed.

When the channel count does not map to the channel indices used, the
result is that MainWindow::UserInfoChanged() uses incorrect channel
indices.

This patch fixes a problem where the Mute checkbox does not work.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
