### PR TITLE
Stop authentication timeout on login success

### DIFF
--- a/ninjam/server/usercon.cpp
+++ b/ninjam/server/usercon.cpp
@@ -766,6 +766,7 @@ void User_Connection::authenticationTimeout()
 
 void User_Connection::userLookupCompleted()
 {
+  authenticationTimer.stop();
   if (!OnRunAuth())
   {
     m_netcon.Kill();


### PR DESCRIPTION
We forgot to stop the timer when authentication completes.  This caused
all users to be disconnected after 120 seconds.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
