### PR TITLE
Move broadcast and metronome out of channel tree widget

### DIFF
--- a/ninjam/qtclient/ChannelTreeWidget.cpp
+++ b/ninjam/qtclient/ChannelTreeWidget.cpp
@@ -21,8 +21,7 @@
 
 enum
 {
-  ItemTypeMetronome = 0,
-  ItemTypeLocalChannel,
+  ItemTypeLocalChannel = 0,
   ItemTypeRemoteChannel,
 
   ItemTypeRole = Qt::UserRole,
@@ -39,8 +38,6 @@ ChannelTreeWidget::ChannelTreeWidget(QWidget *parent)
   setSelectionMode(QAbstractItemView::NoSelection);
 
   QTreeWidgetItem *local = addRootItem("Local");
-  QTreeWidgetItem *metronome = addChannelItem(local, "Metronome");
-  metronome->setData(0, ItemTypeRole, ItemTypeMetronome);
 
   connect(this, SIGNAL(itemChanged(QTreeWidgetItem*, int)),
           this, SLOT(handleItemChanged(QTreeWidgetItem*, int)));
@@ -82,11 +79,6 @@ void ChannelTreeWidget::handleItemChanged(QTreeWidgetItem *item, int column)
 
   bool state = item->data(column, Qt::CheckStateRole).toBool();
   switch (itemType.toInt(NULL)) {
-  case ItemTypeMetronome:
-    if (column == 1) {
-      emit MetronomeMuteChanged(state);
-    }
-    break;
   case ItemTypeLocalChannel:
   {
     int ch = item->data(0, ChannelIndexRole).toInt(NULL);

--- a/ninjam/qtclient/ChannelTreeWidget.h
+++ b/ninjam/qtclient/ChannelTreeWidget.h
@@ -56,7 +56,6 @@ public:
   };
 
 signals:
-  void MetronomeMuteChanged(bool mute);
   void LocalChannelMuteChanged(int ch, bool mute);
   void RemoteChannelMuteChanged(int useridx, int channelidx, bool mute);
 

--- a/ninjam/qtclient/MainWindow.cpp
+++ b/ninjam/qtclient/MainWindow.cpp
@@ -114,8 +114,6 @@ MainWindow::MainWindow(QWidget *parent)
 
   channelTree = new ChannelTreeWidget(this);
   setupChannelTree();
-  connect(channelTree, SIGNAL(MetronomeMuteChanged(bool)),
-          this, SLOT(MetronomeMuteChanged(bool)));
   connect(channelTree, SIGNAL(LocalChannelMuteChanged(int, bool)),
           this, SLOT(LocalChannelMuteChanged(int, bool)));
   connect(channelTree, SIGNAL(RemoteChannelMuteChanged(int, int, bool)),
@@ -605,11 +603,6 @@ void MainWindow::SendChatMessage(const QString &line)
   if (!connected) {
     chatOutput->addErrorMessage("not connected to a server.");
   }
-}
-
-void MainWindow::MetronomeMuteChanged(bool mute)
-{
-  client.config_metronome_mute = mute;
 }
 
 void MainWindow::LocalChannelMuteChanged(int ch, bool mute)

--- a/ninjam/qtclient/MainWindow.h
+++ b/ninjam/qtclient/MainWindow.h
@@ -66,7 +66,6 @@ private slots:
   void ClientStatusChanged(int newStatus);
   void BeatsPerIntervalChanged(int bpm);
   void BeatsPerMinuteChanged(int bpi);
-  void MetronomeMuteChanged(bool mute);
   void LocalChannelMuteChanged(int ch, bool mute);
   void RemoteChannelMuteChanged(int useridx, int channelidx, bool mute);
   void ShowAboutDialog();


### PR DESCRIPTION
The ChannelTreeWidget packs mute and broadcast controls for the metronome, local channels, and remote channels together.  This sometimes confuses users, especially when "mute" and "broadcast" concepts are shown so closely together - the user may not understand that muting a local channel supresses its playback but still uploads the audio to the server.

This patch series implements a new UI idea to simplify the experience:
1. There is a Xmit toggle button in the status bar.  When the Xmit button is depressed audio from local channels is uploaded to the server so other users can hear it.
2. The ChannelTreeWidget no longer displays a broadcast checkbox.
3. There is a Metronome toggle button in the status bar.  When the Metronome button is depressed the metronome can be heard.
4. The ChannelTreeWidget no longer displays a metronome local channel.

I would like to find SVG icons for these toggle buttons.  The Xmit button would be a record symbol (red circle) indicating that local audio is "live" and being uploaded when depressed.  The Metronome button would be a stylized metronome.  For now I have used text because I don't have the SVG graphics.

After this patch series I want to continue simplifying the UI.  Local channels will disappear completely from the ChannelTreeWidget.  Instead the user can set them up in the audio configuration dialog.  The local channel mute is also configured there because it is typically never changed during playing - it basically indicates whether to use software monitoring or not.
