### PR TITLE
Move NJClient::Disconnect() m_downloads.Empty()

### DIFF
--- a/ninjam/njclient.cpp
+++ b/ninjam/njclient.cpp
@@ -614,7 +614,7 @@ void NJClient::Disconnect()
   bool removedUsers = x;
 
   for (x = 0; x < m_downloads.GetSize(); x ++) delete m_downloads.Get(x);
-
+  m_downloads.Empty();
 
   for (x = 0; x < m_locchannels.GetSize(); x ++) 
   {
@@ -632,7 +632,6 @@ void NJClient::Disconnect()
 
     c->m_bq.Clear();
   }
-  m_downloads.Empty();
 
   m_wavebq->Clear();
 


### PR DESCRIPTION
Clearing m_downloads requires first deleting each RemoteDownload and
then emptying the list itself.  Make these two steps adjacent in the
source code to eliminate the risk of accessing a freed RemoteDownload
before m_downloads.Empty() is called.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
