### PR TITLE
Choose best available host API on first start

### DIFF
--- a/ninjam/qtclient/PortAudioConfigDialog.cpp
+++ b/ninjam/qtclient/PortAudioConfigDialog.cpp
@@ -115,7 +115,45 @@ QString PortAudioConfigDialog::hostAPI() const
 void PortAudioConfigDialog::setHostAPI(const QString &name)
 {
   int i = hostAPIList->findText(name);
-  if (i >= 0) {
+  if (i != -1) {
+    hostAPIList->setCurrentIndex(i);
+    return;
+  }
+
+  /* Pick default host API based on this list of priorities */
+  const int hostAPIPriority[] = {
+    0, /* paInDevelopment */
+    1, /* paDirectSound */
+    0, /* paMME */
+    4, /* paASIO */
+    0, /* paSoundManager */
+    1, /* paCoreAudio */
+    0, /* <empty> */
+    0, /* paOSS */
+    1, /* paALSA */
+    0, /* paAL */
+    0, /* paBeOS */
+    3, /* paWDMKS */
+    2, /* paJACK */
+    2, /* paWASAPI */
+    0, /* paAudioScienceHPI */
+  };
+  const PaHostApiTypeId numTypes =
+    (PaHostApiTypeId)(sizeof(hostAPIPriority) / sizeof(hostAPIPriority[0]));
+  int pri = -1;
+
+  for (int j = 0; j < hostAPIList->count(); j++) {
+    PaHostApiIndex apiIndex = hostAPIList->itemData(j).toInt(NULL);
+    const PaHostApiInfo *hostAPIInfo = Pa_GetHostApiInfo(apiIndex);
+    if (!hostAPIInfo || hostAPIInfo->type >= numTypes) {
+      continue;
+    }
+    if (hostAPIPriority[hostAPIInfo->type] > pri) {
+      pri = hostAPIPriority[hostAPIInfo->type];
+      i = j;
+    }
+  }
+  if (i != -1) {
     hostAPIList->setCurrentIndex(i);
   }
 }


### PR DESCRIPTION
Users are often confused between the different audio host APIs available
on their platforms (e.g. WinMME, DirectSound, WDMKS, WASAPI, ASIO).
They may choose an API with poor latency and get a poor playing
experience.

Pick the default host API on behalf of the user.  This way most users
automatically see the best host API for their platform.  The list of
host APIs is prioritized as follows:

Windows: WinMME < DirectSound < WASAPI < WDMKS < ASIO
Linux: OSS < ALSA < JACK
Mac: SoundManager < CoreAudio

Note that although WASAPI is a newer API than WDMKS, in my testing WDMKS
has worked more reliably.

Also note that JACK only appears on Linux if the JACK daemon is running.
Therefore users typically see ALSA by default (which is a fair choice)
but JACK will take priority if the daemon is running (which is usually
what the user expects).

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
