### PR TITLE
Auto reconnect

### DIFF
--- a/common/njclient.cpp
+++ b/common/njclient.cpp
@@ -655,6 +655,14 @@ void NJClient::Connect(char *host, char *user, char *pass)
   emit statusChanged(m_status);
 }
 
+void NJClient::Reconnect()
+{
+  QByteArray host(m_host.Get());
+  QByteArray user(m_user.Get());
+  QByteArray pass(m_pass.Get());
+  Connect(host.data(), user.data(), pass.data());
+}
+
 int NJClient::GetStatus()
 {
   return m_status;

--- a/common/njclient.h
+++ b/common/njclient.h
@@ -84,6 +84,7 @@ public:
 
   void Connect(char *host, char *user, char *pass);
   void Disconnect();
+  void Reconnect();
 
   char *GetErrorStr() { return m_errstr.Get(); }
 

--- a/qtclient/MainWindow.h
+++ b/qtclient/MainWindow.h
@@ -77,6 +77,7 @@ private slots:
   void VoteBPIDialog();
   void XmitToggled(bool checked);
   void MetronomeToggled(bool checked);
+  void Reconnect();
 
 private:
   static MainWindow *instance;
@@ -100,11 +101,16 @@ private:
   QState *connectingState;
   QState *connectedState;
   QState *disconnectedState;
+  QTimer *reconnectTimer;
+  int reconnectTries;
+  int reconnectMilliseconds;
 
   void setupChannelTree();
   void setupStatusBar();
   bool setupWorkDir();
   void cleanupWorkDir(const QString &path);
+  bool tryReconnect();
+  void resetReconnect();
   void OnSamples(float **inbuf, int innch, float **outbuf, int outnch, int len, int srate);
   void chatAddLine(const QString &prefix, const QString &content,
                    const QString &href = "", const QString &linktext = "");


### PR DESCRIPTION
This series implements exponential back-off reconnect.  If the client is unable to connect due to a network error, it tries again after 3 seconds, then 6 seconds, then 12 seconds, and so on until a maximum limit is reached.

In order to implement this feature the early patches clean up the NJClient state machine.
