### PR TITLE
Fix win32 libcommon.a dependencies

### DIFF
--- a/common/libcommon.pri
+++ b/common/libcommon.pri
@@ -1,0 +1,12 @@
+win32 {
+    CONFIG(release, debug|release) {
+        common_path = ../common/release
+    } else {
+        common_path = ../common/debug
+    }
+} else {
+    common_path = ../common
+}
+
+LIBS += -L$${common_path} -lcommon
+PRE_TARGETDEPS += $${common_path}/libcommon.a

--- a/qtclient/qtclient.pro
+++ b/qtclient/qtclient.pro
@@ -13,8 +13,7 @@ DEPENDPATH += ..
 INCLUDEPATH += ..
 QT += network
 
-LIBS += -L../common -lcommon
-PRE_TARGETDEPS += ../common/libcommon.a
+include(../common/libcommon.pri)
 
 QMAKE_CXXFLAGS += -Wno-write-strings
 CONFIG += link_pkgconfig

--- a/server/server.pro
+++ b/server/server.pro
@@ -14,8 +14,7 @@ INCLUDEPATH += ..
 QT -= gui
 QT += network
 
-LIBS += -L../common -lcommon
-PRE_TARGETDEPS += ../common/libcommon.a
+include(../common/libcommon.pri)
 
 # Code in common/ does not use wide characters
 win32:DEFINES -= UNICODE


### PR DESCRIPTION
qmake does not take care of sub-project dependencies automatically.
qtclient.pro and server.pro manually specify dependencies on
libcommon.a.  The path to libcommon.a is different when cross-compiling
for win32 since there is a release/ or debug/ subdirectory.

Capture the ugly details of the libcommon.a dependency in a qmake
include file which qtclient.pro and server.pro can include.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
