### PR TITLE
Set clipsort.log filename if saving session

### DIFF
--- a/qtclient/MainWindow.cpp
+++ b/qtclient/MainWindow.cpp
@@ -357,6 +357,10 @@ bool MainWindow::setupWorkDir()
 
     if (basedir.mkdir(filename)) {
       client.SetWorkDir(basedir.filePath(filename).toUtf8().data());
+      if (client.config_savelocalaudio != -1) {
+        QDir workdir(basedir.filePath(filename));
+        client.SetLogFile(workdir.filePath("clipsort.log").toUtf8().data());
+      }
       return true;
     }
   }


### PR DESCRIPTION
Don't forget to set up the clipsort.log filename so the client records
ogg file interval information.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
