### PR TITLE
Fix metronome status bar button

### DIFF
--- a/qtclient/MainWindow.cpp
+++ b/qtclient/MainWindow.cpp
@@ -104,6 +104,7 @@ MainWindow::MainWindow(QWidget *parent)
   connect(aboutAction, SIGNAL(triggered()), this, SLOT(ShowAboutDialog()));
 
   setupStatusBar();
+  client.config_metronome_mute = !metronomeButton->isChecked();
 
   setWindowTitle(tr("Wahjam"));
 


### PR DESCRIPTION
Apply the state of the metronome status bar button on startup.  This
ensures the GUI is in sync with the client.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
