### PR TITLE
Manual audio config controls

### DIFF
--- a/common/audiostream.h
+++ b/common/audiostream.h
@@ -47,7 +47,8 @@ class audioStreamer
 typedef void (*SPLPROC)(float **inbuf, int innch, float **outbuf, int outnch, int len, int srate);
 
 audioStreamer *create_audioStreamer_PortAudio(const char *hostAPI,
-    const char *inputDevice, const char *outputDevice, SPLPROC proc);
+    const char *inputDevice, const char *outputDevice,
+    double sampleRate, double latency, SPLPROC proc);
 bool portAudioInit();
 
 #endif

--- a/qtclient/MainWindow.cpp
+++ b/qtclient/MainWindow.cpp
@@ -286,7 +286,9 @@ void MainWindow::Startup()
   /* Pop up audio configuration dialog, if necessary */
   if (!settings->contains("audio/hostAPI") ||
       !settings->contains("audio/inputDevice") ||
-      !settings->contains("audio/outputDevice")) {
+      !settings->contains("audio/outputDevice") ||
+      !settings->contains("audio/sampleRate") ||
+      !settings->contains("audio/latency")) {
     ShowAudioConfigDialog();
   }
 
@@ -304,9 +306,12 @@ void MainWindow::Connect(const QString &host, const QString &user, const QString
   QString inputDevice = settings->value("audio/inputDevice").toString();
   bool unmuteLocalChannels = settings->value("audio/unmuteLocalChannels", true).toBool();
   QString outputDevice = settings->value("audio/outputDevice").toString();
+  double sampleRate = settings->value("audio/sampleRate").toDouble();
+  double latency = settings->value("audio/latency").toDouble();
   audio = create_audioStreamer_PortAudio(hostAPI.toLocal8Bit().data(),
                                          inputDevice.toLocal8Bit().data(),
                                          outputDevice.toLocal8Bit().data(),
+                                         sampleRate, latency,
                                          OnSamplesTrampoline);
   if (!audio)
   {
@@ -528,12 +533,16 @@ void MainWindow::ShowAudioConfigDialog()
   audioDialog.setInputDevice(settings->value("audio/inputDevice").toString());
   audioDialog.setUnmuteLocalChannels(settings->value("audio/unmuteLocalChannels", true).toBool());
   audioDialog.setOutputDevice(settings->value("audio/outputDevice").toString());
+  audioDialog.setSampleRate(settings->value("audio/sampleRate").toDouble());
+  audioDialog.setLatency(settings->value("audio/latency").toDouble());
 
   if (audioDialog.exec() == QDialog::Accepted) {
     settings->setValue("audio/hostAPI", audioDialog.hostAPI());
     settings->setValue("audio/inputDevice", audioDialog.inputDevice());
     settings->setValue("audio/unmuteLocalChannels", audioDialog.unmuteLocalChannels());
     settings->setValue("audio/outputDevice", audioDialog.outputDevice());
+    settings->setValue("audio/sampleRate", audioDialog.sampleRate());
+    settings->setValue("audio/latency", audioDialog.latency());
   }
 }
 

--- a/qtclient/PortAudioConfigDialog.cpp
+++ b/qtclient/PortAudioConfigDialog.cpp
@@ -16,8 +16,8 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
+#include <math.h>
 #include <portaudio.h>
-#include <QPushButton>
 #include <QFormLayout>
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -25,23 +25,37 @@
 #include "PortAudioConfigDialog.h"
 
 PortAudioConfigDialog::PortAudioConfigDialog(QWidget *parent)
-  : QDialog(parent)
+  : QDialog(parent), validateSettingsEntryCount(0)
 {
   inputDeviceList = new QComboBox;
   inputDeviceList->setEditable(false);
+  connect(inputDeviceList, SIGNAL(currentIndexChanged(int)),
+          this, SLOT(deviceIndexChanged(int)));
 
   unmuteLocalChannelsBox = new QCheckBox(tr("Play back my audio"));
   unmuteLocalChannelsBox->setToolTip(tr("Disable if you play an acoustic instrument"));
 
   outputDeviceList = new QComboBox;
   outputDeviceList->setEditable(false);
+  connect(outputDeviceList, SIGNAL(currentIndexChanged(int)),
+          this, SLOT(deviceIndexChanged(int)));
+
+  sampleRateList = new QComboBox;
+  sampleRateList->setEditable(false);
+  sampleRateList->addItems(QStringList() << "32000" << "44100" << "48000" << "88200" << "96000");
+  connect(sampleRateList, SIGNAL(currentIndexChanged(int)),
+          this, SLOT(sampleRateIndexChanged(int)));
+
+  latencyList = new QComboBox();
+  connect(latencyList, SIGNAL(currentIndexChanged(int)),
+          this, SLOT(latencyIndexChanged(int)));
 
   hostAPIList = new QComboBox;
   hostAPIList->setEditable(false);
   connect(hostAPIList, SIGNAL(currentIndexChanged(int)),
           this, SLOT(hostAPIIndexChanged(int)));
 
-  QPushButton *applyButton = new QPushButton(tr("&Apply"));
+  applyButton = new QPushButton(tr("&Apply"));
   connect(applyButton, SIGNAL(clicked()), this, SLOT(accept()));
 
   QPushButton *cancelButton = new QPushButton(tr("&Cancel"));
@@ -54,6 +68,9 @@ PortAudioConfigDialog::PortAudioConfigDialog(QWidget *parent)
   formLayout->addRow(tr("&Input device:"), inputDeviceList);
   formLayout->addRow(new QLabel, unmuteLocalChannelsBox);
   formLayout->addRow(tr("&Output device:"), outputDeviceList);
+  formLayout->addRow(new QLabel); /* just a spacer */
+  formLayout->addRow(tr("Sample &rate (Hz):"), sampleRateList);
+  formLayout->addRow(tr("&Latency (ms):"), latencyList);
   formLayout->addRow(new QLabel); /* just a spacer */
   formLayout->addRow(new QLabel(tr("<b>Troubleshooting:</b> If you experience audio problems, try selecting another audio system.")));
   formLayout->addRow(tr("Audio &system:"), hostAPIList);
@@ -82,6 +99,142 @@ void PortAudioConfigDialog::populateHostAPIList()
       hostAPIList->addItem(name, i);
     }
   }
+}
+
+void PortAudioConfigDialog::willValidateSettings()
+{
+  validateSettingsEntryCount++;
+}
+
+void PortAudioConfigDialog::validateSettings()
+{
+  /* Avoid repeating validation because Pa_IsFormatSupported() can be
+   * slow and we should not block the GUI thread for too long.
+   */
+  if (--validateSettingsEntryCount > 1) {
+    return;
+  }
+
+  double sampleRate = sampleRateList->currentText().toDouble();
+  double latency = latencyList->currentText().toDouble() / 1000;
+
+  if (sampleRate == 0 ||
+      latency == 0 ||
+      inputDeviceList->currentIndex() < 0 ||
+      outputDeviceList->currentIndex() < 0) {
+    applyButton->setEnabled(false);
+    return;
+  }
+
+  PaStreamParameters inputParams;
+  inputParams.device = inputDeviceList->itemData(inputDeviceList->currentIndex()).toInt(NULL);
+  inputParams.channelCount = 1 /* TODO mono */;
+  inputParams.sampleFormat = paFloat32 | paNonInterleaved;
+  inputParams.suggestedLatency = latency;
+  inputParams.hostApiSpecificStreamInfo = NULL;
+
+  PaStreamParameters outputParams = inputParams;
+  outputParams.device = outputDeviceList->itemData(outputDeviceList->currentIndex()).toInt(NULL);
+  outputParams.channelCount = 1 /* TODO mono */;
+
+  PaError error = Pa_IsFormatSupported(&inputParams, &outputParams, sampleRate);
+  applyButton->setEnabled(error == paFormatIsSupported);
+}
+
+/* Return PaDeviceInfo* or NULL if not found */
+static const PaDeviceInfo *lookupDeviceInfo(QComboBox *deviceList)
+{
+  int index = deviceList->currentIndex();
+  if (index < 0) {
+    return NULL;
+  }
+  PaDeviceIndex deviceIndex = deviceList->itemData(index).toInt(NULL);
+  return Pa_GetDeviceInfo(deviceIndex);
+}
+
+void PortAudioConfigDialog::autoselectSampleRate()
+{
+  const PaDeviceInfo *inputDeviceInfo = lookupDeviceInfo(inputDeviceList);
+  if (!inputDeviceInfo) {
+    return;
+  }
+
+  const PaDeviceInfo *outputDeviceInfo = lookupDeviceInfo(outputDeviceList);
+  if (!outputDeviceInfo) {
+    return;
+  }
+
+  double sampleRate = qMin(inputDeviceInfo->defaultSampleRate,
+                           outputDeviceInfo->defaultSampleRate);
+  int index = sampleRateList->findText(QString::number(sampleRate));
+  if (index != -1) {
+    sampleRateList->setCurrentIndex(index);
+  }
+}
+
+void PortAudioConfigDialog::autoselectLatency()
+{
+  const PaDeviceInfo *inputDeviceInfo = lookupDeviceInfo(inputDeviceList);
+  if (!inputDeviceInfo) {
+    return;
+  }
+
+  const PaDeviceInfo *outputDeviceInfo = lookupDeviceInfo(outputDeviceList);
+  if (!outputDeviceInfo) {
+    return;
+  }
+
+  double latency = qMax(inputDeviceInfo->defaultLowInputLatency,
+                        outputDeviceInfo->defaultLowOutputLatency) * 1000;
+  int i;
+  for (i = 0; i < latencyList->count(); i++) {
+    if (latency < latencyList->itemText(i).toDouble() - .01 /* epsilon */) {
+      if (i > 0) {
+        i--;
+      }
+      latencyList->setCurrentIndex(i);
+      return;
+    }
+  }
+}
+
+void PortAudioConfigDialog::setupLatencyList()
+{
+  latencyList->clear();
+
+  /* Enumerate latencies for power-of-2 buffers up to 4096 frames.  Start
+   * at 1 millisecond since lower latencies are unlikely to produce
+   * glitch-free audio.
+   */
+  double sampleRate = sampleRateList->currentText().toDouble();
+  if (sampleRate <= 0) {
+    return;
+  }
+  int framesPerMillisecond = 1 << (int)ceil(log2(sampleRate / 1000));
+  for (int i = framesPerMillisecond; i < 4096; i *= 2) {
+    latencyList->addItem(QString::number(i / sampleRate * 1000, 'g', 3));
+  }
+}
+
+void PortAudioConfigDialog::deviceIndexChanged(int index)
+{
+  willValidateSettings();
+  autoselectSampleRate();
+  validateSettings();
+}
+
+void PortAudioConfigDialog::sampleRateIndexChanged(int index)
+{
+  willValidateSettings();
+  setupLatencyList();
+  autoselectLatency();
+  validateSettings();
+}
+
+void PortAudioConfigDialog::latencyIndexChanged(int index)
+{
+  willValidateSettings();
+  validateSettings();
 }
 
 void PortAudioConfigDialog::hostAPIIndexChanged(int index)
@@ -198,5 +351,31 @@ void PortAudioConfigDialog::setOutputDevice(const QString &name)
   int i = outputDeviceList->findText(name);
   if (i >= 0) {
     outputDeviceList->setCurrentIndex(i);
+  }
+}
+
+double PortAudioConfigDialog::sampleRate() const
+{
+  return sampleRateList->currentText().toDouble();
+}
+
+void PortAudioConfigDialog::setSampleRate(double sampleRate)
+{
+  int i = sampleRateList->findText(QString::number(sampleRate));
+  if (i >= 0) {
+    sampleRateList->setCurrentIndex(i);
+  }
+}
+
+double PortAudioConfigDialog::latency() const
+{
+  return latencyList->currentText().toDouble() / 1000;
+}
+
+void PortAudioConfigDialog::setLatency(double latency)
+{
+  int i = latencyList->findText(QString::number(latency * 1000, 'g', 3));
+  if (i >= 0) {
+    latencyList->setCurrentIndex(i);
   }
 }

--- a/qtclient/PortAudioConfigDialog.h
+++ b/qtclient/PortAudioConfigDialog.h
@@ -22,6 +22,7 @@
 #include <QDialog>
 #include <QComboBox>
 #include <QCheckBox>
+#include <QPushButton>
 
 class PortAudioConfigDialog : public QDialog
 {
@@ -30,6 +31,8 @@ class PortAudioConfigDialog : public QDialog
   Q_PROPERTY(QString inputDevice READ inputDevice WRITE setInputDevice)
   Q_PROPERTY(bool unmuteLocalChannels READ unmuteLocalChannels WRITE setUnmuteLocalChannels)
   Q_PROPERTY(QString outputDevice READ outputDevice WRITE setOutputDevice)
+  Q_PROPERTY(double sampleRate READ sampleRate WRITE setSampleRate)
+  Q_PROPERTY(double latency READ latency WRITE setLatency)
 
 public:
   PortAudioConfigDialog(QWidget *parent = 0);
@@ -42,8 +45,15 @@ public:
   void setUnmuteLocalChannels(bool unmute);
   QString outputDevice() const;
   void setOutputDevice(const QString &name);
+  double sampleRate() const;
+  void setSampleRate(double sampleRate);
+  double latency() const;
+  void setLatency(double latency);
 
 private slots:
+  void deviceIndexChanged(int index);
+  void sampleRateIndexChanged(int index);
+  void latencyIndexChanged(int index);
   void hostAPIIndexChanged(int index);
 
 private:
@@ -51,6 +61,16 @@ private:
   QComboBox *inputDeviceList;
   QCheckBox *unmuteLocalChannelsBox;
   QComboBox *outputDeviceList;
+  QComboBox *sampleRateList;
+  QComboBox *latencyList;
+  QPushButton *applyButton;
+  int validateSettingsEntryCount;
+
+  void willValidateSettings();
+  void validateSettings();
+  void autoselectSampleRate();
+  void autoselectLatency();
+  void setupLatencyList();
 };
 
 #endif /* _PORTAUDIOCONFIGDIALOG_H_ */


### PR DESCRIPTION
This series introduces sample rate and latency controls in the audio configuration dialog.  They can be used to find the optimal balance between low-latency and audio glitches.

When latency is too low it becomes harder for the CPU to keep up, resulting in audio glitches when audio data is not processed on time.  When latency is too high there is a noticable delay between playing a note and hearing it.

Unfortunately it is not possible to autoselect the right settings on every system so these manual controls allow the user to find the optimal values.
