### PR TITLE
Add built-time option to use -lporttime

### DIFF
--- a/qtclient/qtclient.pro
+++ b/qtclient/qtclient.pro
@@ -55,6 +55,11 @@ CONFIG += link_pkgconfig
 PKGCONFIG += vorbis vorbisenc portaudio-2.0
 LIBS += -lportmidi # does not use pkg-config
 
+# On Ubuntu PortTime is separate from PortMidi
+!isEmpty(USE_LIBPORTTIME) {
+	LIBS += -lporttime
+}
+
 # Code in common/ does not use wide characters
 win32:DEFINES -= UNICODE
 


### PR DESCRIPTION
The Ubuntu package for PortMidi ships a separate libporttime.so.  Other
distributions ship a single libportmidi.so.  Add an option to the
project file so it can be selected at build-time.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
