### PR TITLE
Add ssl/verify configuration setting

### DIFF
--- a/qtclient/MainWindow.cpp
+++ b/qtclient/MainWindow.cpp
@@ -29,6 +29,7 @@
 #include <QUrl>
 #include <QInputDialog>
 #include <QRegExp>
+#include <QSslConfiguration>
 
 #include "MainWindow.h"
 #include "ConnectDialog.h"
@@ -84,6 +85,13 @@ MainWindow::MainWindow(QWidget *parent)
   client.SetLocalChannelInfo(0, "channel0", true, 0, false, 0, true, true);
   client.SetLocalChannelMonitoring(0, false, 0.0f, false, 0.0f, false, false, false, false);
   client.SetMidiOutput(portMidiStreamer.getOutputQueue());
+
+  /* Certificate verification can be disabled for local testing */
+  if (!settings->value("ssl/verify", true).toBool()) {
+    QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
+    sslConfig.setPeerVerifyMode(QSslSocket::QueryPeer);
+    QSslConfiguration::setDefaultConfiguration(sslConfig);
+  }
 
   netManager = new QNetworkAccessManager(this);
 


### PR DESCRIPTION
Production SSL certificates should always have a trusted root
Certificate Authority.  Development and testing certificates are often
self-signed and therefore fail verification.

The new ssl/verify configuration setting can be used to disable
verification.  This setting is not exposed from the GUI since it only
makes sense for developers.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
