### PR TITLE
Skip missing wahjam Mac icns file

### DIFF
--- a/qtclient/qtclient.pro
+++ b/qtclient/qtclient.pro
@@ -63,8 +63,12 @@ LIBS += -lportmidi # does not use pkg-config
 # Code in common/ does not use wide characters
 win32:DEFINES -= UNICODE
 
-mac:QMAKE_INFO_PLIST = Info.plist-$${TARGET}
-mac:ICON = $${TARGET}.icns
+mac {
+	QMAKE_INFO_PLIST = Info.plist-$${TARGET}
+	exists($${TARGET}.icns) {
+		ICON = $${TARGET}.icns
+	}
+}
 
 # Input
 HEADERS += MainWindow.h


### PR DESCRIPTION
We don't have an icns file for wahjam on Mac.  Skip the missing file to
build successfully without an application icon.

Currently only jammr has a Mac icon.  In the future a vanilla Wahjam
icon can be added using this per-TARGET file.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
