### PR TITLE
Use Qt5 Q_OS_* macros instead of Q_WS_*

### DIFF
--- a/qtclient/AddVSTPluginDialog.cpp
+++ b/qtclient/AddVSTPluginDialog.cpp
@@ -160,7 +160,7 @@ void AddVSTPluginDialog::scan()
   while (!searchPaths.isEmpty()) {
     QDir dir(searchPaths.takeFirst());
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
     if (!dir.dirName().endsWith(".vst", Qt::CaseInsensitive)) {
 #endif
       QStringList subdirs = dir.entryList(QDir::Dirs | QDir::Readable |
@@ -170,7 +170,7 @@ void AddVSTPluginDialog::scan()
       foreach (subdir, subdirs) {
         searchPaths.append(dir.filePath(subdir));
       }
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
     } else {
       if (!dir.cd("Contents/MacOS")) {
         continue;
@@ -179,12 +179,12 @@ void AddVSTPluginDialog::scan()
       QStringList files = dir.entryList(QDir::Files);
       QString file;
       foreach (file, files) {
-#ifndef Q_WS_MAC
+#ifndef Q_OS_MAC
         /* On Linux and Windows VST filenames include the library suffix */
         if (!QLibrary::isLibrary(file)) {
           continue;
         }
-#endif /* Q_WS_MAC */
+#endif /* Q_OS_MAC */
 
         file = dir.filePath(file);
         VSTPlugin vst(file);
@@ -197,7 +197,7 @@ void AddVSTPluginDialog::scan()
         /* Process UI thread events, scanning plugins might take a while */
         QCoreApplication::processEvents();
       }
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
     }
 #endif
   }

--- a/qtclient/VSTSettingsPage.cpp
+++ b/qtclient/VSTSettingsPage.cpp
@@ -28,9 +28,9 @@ VSTSettingsPage::VSTSettingsPage(VSTProcessor *processor_, QWidget *parent)
   int i;
   QString defaultSearchPath;
 
-#if defined(Q_WS_MAC)
+#if defined(Q_OS_MAC)
   defaultSearchPath = "~/Library/Audio/Plug-Ins/VST;/Library/Audio/Plug-Ins/VST";
-#elif defined(Q_WS_WIN)
+#elif defined(Q_OS_WIN)
   if (sizeof(void*) == 4) {
     defaultSearchPath = QSettings("HKEY_LOCAL_MACHINE\\Software\\Wow6432Node\\VST",
                                   QSettings::NativeFormat).value("VSTPluginsPath").toString();

--- a/qtclient/logging.cpp
+++ b/qtclient/logging.cpp
@@ -58,7 +58,7 @@ static void logSystemInformation()
          QSysInfo::ByteOrder == QSysInfo::LittleEndian ?
          "little-endian" : "big-endian");
 
-#if defined(Q_WS_WIN)
+#if defined(Q_OS_WIN)
   switch (QSysInfo::windowsVersion()) {
   case QSysInfo::WV_2000:
     qDebug("Windows 2000");
@@ -79,7 +79,7 @@ static void logSystemInformation()
     qDebug("Unsupported or unrecognized Windows version");
     break;
   }
-#elif defined(Q_WS_MAC)
+#elif defined(Q_OS_MAC)
   switch (QSysInfo::MacintoshVersion) {
   case QSysInfo::MV_10_3:
     qDebug("Mac OS X 10.3");
@@ -130,7 +130,7 @@ void logInit(const QString &filename)
   if (!logfp) {
     logfp = stderr;
   }
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
   /* Windows does not support line-buffering, so use no buffering */
   setvbuf(logfp, NULL, _IONBF, 0);
 

--- a/server/logging.cpp
+++ b/server/logging.cpp
@@ -75,7 +75,7 @@ void logInit(const QString &filename)
   if (!logfp) {
     logfp = stdout;
   }
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
   /* Windows does not support line-buffering, so use no buffering */
   setvbuf(logfp, NULL, _IONBF, 0);
 #else


### PR DESCRIPTION
The Q_OS_\* macros should be used instead of Q_WS_\* in Qt5:
https://qt-project.org/doc/qt-5.0/qtdoc/portingguide.html

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
