### PR TITLE
Fix Mac build paths

### DIFF
--- a/common/common.pro
+++ b/common/common.pro
@@ -7,6 +7,10 @@ QT -= gui
 CONFIG += link_pkgconfig
 PKGCONFIG += ogg vorbis vorbisenc portaudio-2.0
 
+mac {
+       INCLUDEPATH += /usr/local/Cellar/portmidi/217/include
+}
+
 QMAKE_CXXFLAGS += -Wno-write-strings
 win32:DEFINES -= UNICODE
 SOURCES = audiostream_pa.cpp \

--- a/qtclient/qtclient.pro
+++ b/qtclient/qtclient.pro
@@ -53,7 +53,13 @@ include(../common/libcommon.pri)
 QMAKE_CXXFLAGS += -Wno-write-strings
 CONFIG += link_pkgconfig
 PKGCONFIG += ogg vorbis vorbisenc portaudio-2.0
-LIBS += -lportmidi # does not use pkg-config
+
+# portmidi does not use pkg-config
+mac {
+       INCLUDEPATH += /usr/local/Cellar/portmidi/217/include
+       LIBS += -L/usr/local/Cellar/portmidi/217/lib
+}
+LIBS += -lportmidi
 
 # On Ubuntu PortTime is separate from PortMidi
 !isEmpty(USE_LIBPORTTIME) {


### PR DESCRIPTION
The build is a little harder on Mac where dependencies are not installed in the default include and link paths.  These patches let the build work out-of-the-box on Mac when using the homebrew (http://brew.sh/) package manager.
