### PR TITLE
Fix overlapping memcpy() in WDL_PtrList::Delete()

### DIFF
--- a/WDL/ptrlist.h
+++ b/WDL/ptrlist.h
@@ -112,7 +112,7 @@ template<class PTRTYPE> class WDL_PtrList
           if (delfunc) delfunc(Get(index));
           else delete Get(index);
         }
-        if (index < --size) memcpy(list+index,list+index+1,sizeof(PTRTYPE *)*(size-index));
+        if (index < --size) memmove(list+index,list+index+1,sizeof(PTRTYPE *)*(size-index));
         m_hb.Resize(size * sizeof(PTRTYPE*));
       }
     }


### PR DESCRIPTION
The memmove() function must be used when memory ranges overlap.  Some C
standard library implementations take advantage of this constraint and
the data can be corrupted if memcpy() is used.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
