### PR TITLE
Drop format=xml from JammrUserLookup HTTP request

### DIFF
--- a/server/JammrUserLookup.cpp
+++ b/server/JammrUserLookup.cpp
@@ -33,7 +33,6 @@ JammrUserLookup::JammrUserLookup(const QUrl &apiUrl,
 {
   QUrlQuery query;
   query.addQueryItem("server", apiServerName);
-  query.addQueryItem("format", "xml");
 
   tokenUrl = apiUrl;
   tokenUrl.setPath(apiUrl.path() + "tokens/" + username_ + "/");


### PR DESCRIPTION
The jammr REST API has been using JSON for some time now.  The
format=xml query argument was a left-over from the old XML REST API.
Luckily the new REST API always emits JSON so this never caused
problems.

Signed-off-by: Stefan Hajnoczi stefanha@gmail.com
