### PR TITLE
Hardcode version number into Info.plist-jammr

### DIFF
--- a/qtclient/Info.plist-jammr
+++ b/qtclient/Info.plist-jammr
@@ -9,9 +9,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleGetInfoString</key>
-	<string>@SHORT_VERSION@</string>
+	<string>1.2.4</string>
 	<key>CFBundleShortVersionString</key>
-	<string>@SHORT_VERSION@</string>
+	<string>1.2.4</string>
 	<key>CFBundleSignature</key>
 	<string>@TYPEINFO@</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
The @SHORT_VERSION@ variable only expands to the x.y version number and
not the x.y.z version number in Apple's documentation.  I have filed a
bug with Qt:

https://bugreports.qt-project.org/browse/QTBUG-40860

In the meantime we can hardcode the full version number.

Signed-off-by: Stefan Hajnoczi <stefanha@gmail.com>