### PR TITLE
Fix spurious ChannelTreeWidget::handleItemChanged() signals

### DIFF
--- a/qtclient/ChannelTreeWidget.h
+++ b/qtclient/ChannelTreeWidget.h
@@ -32,11 +32,9 @@ public:
 
   /*
    * Remote user and channel updates must be performed by enumerating all users
-   * and their channels each time.  Any users or channels present in the last
-   * update but not in the current update will be removed.
-   *
-   * This interface is an artifact of how NJClient only informs us that user
-   * information has changed, but not what specifically to add/remove/update.
+   * and their channels each time.  This interface is an artifact of how
+   * NJClient only informs us that user information has changed, but not what
+   * specifically to add/remove/update.
    */
   class RemoteChannelUpdater
   {
@@ -44,15 +42,11 @@ public:
     RemoteChannelUpdater(ChannelTreeWidget *owner);
     void addUser(int useridx, const QString &name);
     void addChannel(int channelidx, const QString &name, bool mute);
-    void commit();
 
   private:
     ChannelTreeWidget *owner;
-    int toplevelidx;
-    int childidx;
+    QTreeWidgetItem *user;
     int useridx;
-
-    void prunePreviousUser();
   };
 
 signals:
@@ -63,7 +57,8 @@ private slots:
 
 private:
   QTreeWidgetItem *addRootItem(const QString &text);
-  QTreeWidgetItem *addChannelItem(QTreeWidgetItem *parent, const QString &text);
+  void addChannelItem(QTreeWidgetItem *parent, const QString &text,
+                      int useridx, int channelidx, bool mute);
 };
 
 #endif /* _CHANNELTREEWIDGET_H */

--- a/qtclient/MainWindow.cpp
+++ b/qtclient/MainWindow.cpp
@@ -615,8 +615,6 @@ void MainWindow::UserInfoChanged()
       updater.addChannel(channelidx, QString::fromUtf8(name), mute);
     }
   }
-
-  updater.commit();
 }
 
 void MainWindow::OnSamples(float **inbuf, int innch, float **outbuf, int outnch, int len, int srate)


### PR DESCRIPTION
The QTreeWidget::itemChanged() signal is emitted when items are added.
Since we created new QTreeWidgetItem instances with their parent pointer
they were immediately added to the tree before being fully initialized
with the useridx, channelidx, and mute values.

This could result in mute being disabled for useridx 0 channelidx 0
whenever a user joined the jam session.

The ChannelTreeWidget code has been hard to get right.  Simplify it
dramatically by clearing the widget and recreating items on update.  The
previous approach of updating items in place was complicated and hard to
understand.

Signed-off-by: Stefan Hajnoczi <stefanha@gmail.com>