### PR TITLE
Add placeholder text to chat textbox

### DIFF
--- a/qtclient/MainWindow.cpp
+++ b/qtclient/MainWindow.cpp
@@ -176,6 +176,7 @@ MainWindow::MainWindow(QWidget *parent)
                       this, SLOT(ChatLinkClicked(const QUrl&)));
 
   chatInput = new QLineEdit(this);
+  chatInput->setPlaceholderText("Enter your chat message here...");
   chatInput->connect(chatInput, SIGNAL(returnPressed()),
                      this, SLOT(ChatInputReturnPressed()));
 


### PR DESCRIPTION
Users have asked how to send chat messages.  Populate the chat textbox
with a message prompting the user to enter their message.

Signed-off-by: Stefan Hajnoczi <stefanha@gmail.com>