### PR TITLE
Allocate QSettings on the stack

### DIFF
--- a/qtclient/qtclient.cpp
+++ b/qtclient/qtclient.cpp
@@ -18,6 +18,7 @@
 
 #include <QStandardPaths>
 #include <QDir>
+#include <QCoreApplication>
 #include <QApplication>
 #include <QMessageBox>
 #include <QTextCodec>
@@ -42,12 +43,13 @@ int main(int argc, char *argv[])
   }
 
   /* These are used by QSettings persistent settings */
-  app.setOrganizationName(ORGNAME);
-  app.setOrganizationDomain(ORGDOMAIN);
-  app.setApplicationName(APPNAME);
+  QCoreApplication::setOrganizationName(ORGNAME);
+  QCoreApplication::setOrganizationDomain(ORGDOMAIN);
+  QCoreApplication::setApplicationName(APPNAME);
 
   /* Instantiate QSettings now that application information has been set */
-  settings = new QSettings(&app);
+  QSettings appSettings;
+  settings = &appSettings;
 
   /* Set up log file */
   if (settings->contains("app/logFile")) {


### PR DESCRIPTION
Prevent warnings due to an incorrect object lifecycle:

  WARN: QApplication::qAppName: Please instantiate the QApplication object first

QApplication, QSettings, and QMainWindow should be stack allocated, in
that order.

Instead of making QSettings a child object of QApplication, just stack
allocate it.

Signed-off-by: Stefan Hajnoczi <stefanha@gmail.com>