### PR TITLE
Fix "Send" button on startup

### DIFF
--- a/qtclient/MainWindow.cpp
+++ b/qtclient/MainWindow.cpp
@@ -167,7 +167,6 @@ MainWindow::MainWindow(QWidget *parent)
   connect(aboutAction, SIGNAL(triggered()), this, SLOT(ShowAboutDialog()));
 
   setupStatusBar();
-  client.config_metronome_mute = !metronomeButton->isChecked();
 
   setWindowTitle(tr(APPNAME));
 
@@ -295,18 +294,20 @@ void MainWindow::setupStatusBar()
   xmitButton->setText("Send");
   xmitButton->setCheckable(true);
   xmitButton->setToolTip(tr("Send audio to other users"));
+  xmitButton->setChecked(enableXmit);
+  XmitToggled(enableXmit);
   connect(xmitButton, SIGNAL(toggled(bool)),
           this, SLOT(XmitToggled(bool)));
-  xmitButton->setChecked(enableXmit);
   statusBar()->addPermanentWidget(xmitButton);
 
   metronomeButton = new QToolButton(this);
   metronomeButton->setText("Metronome");
   metronomeButton->setCheckable(true);
   metronomeButton->setToolTip(tr("Enable metronome"));
+  metronomeButton->setChecked(enableMetronome);
+  MetronomeToggled(enableMetronome);
   connect(metronomeButton, SIGNAL(toggled(bool)),
           this, SLOT(MetronomeToggled(bool)));
-  metronomeButton->setChecked(enableMetronome);
   statusBar()->addPermanentWidget(metronomeButton);
 
   bpmLabel = new QLabel(this);


### PR DESCRIPTION
When the "Send" button was disabled last time jammr was shut down, it
appears disabled on startup too but audio is actually being transmitted.

This happens because QToolButton->setChecked() does not emit a toggled()
signal if the new state matches the old state.
MainWindow::setupStatusBar() was making this assumption and therefore
didn't disable transmit properly.

Interestingly the metronome suffers the same problem but already had a
fix.  Consolidate both into the setupStatusBar() function.

Signed-off-by: Stefan Hajnoczi <stefanha@gmail.com>