### PR TITLE
Allow digits in jammr usernames

### DIFF
--- a/qtclient/JammrAccessControlDialog.cpp
+++ b/qtclient/JammrAccessControlDialog.cpp
@@ -160,7 +160,7 @@ static bool isUsernameValid(const QString &s)
   if (s.isEmpty() || s.size() > 30) {
     return false;
   }
-  return !s.contains(QRegExp("[^a-zA-Z@+\\.\\-_]"));
+  return !s.contains(QRegExp("[^a-zA-Z0-9@\\.+\\-_]"));
 }
 
 void JammrAccessControlDialog::addUsername()


### PR DESCRIPTION
The jammr access control list validates usernames but was using a
regular expression that was too restrictive.  Allow digits in usernames.

Signed-off-by: Stefan Hajnoczi <stefanha@gmail.com>