### PR TITLE
Allow connect when jam selected

### DIFF
--- a/qtclient/JammrAccessControlDialog.cpp
+++ b/qtclient/JammrAccessControlDialog.cpp
@@ -160,7 +160,7 @@ static bool isUsernameValid(const QString &s)
   if (s.isEmpty() || s.size() > 30) {
     return false;
   }
-  return !s.contains(QRegExp("[^a-zA-Z@+\\.\\-_]"));
+  return !s.contains(QRegExp("[^a-zA-Z0-9@\\.+\\-_]"));
 }
 
 void JammrAccessControlDialog::addUsername()

--- a/qtclient/JammrConnectDialog.cpp
+++ b/qtclient/JammrConnectDialog.cpp
@@ -40,6 +40,7 @@ JammrConnectDialog::JammrConnectDialog(QNetworkAccessManager *netManager_,
           this, SLOT(onServerSelected(const QString &)));
 
   connectButton = new QPushButton(tr("&Connect"));
+  connectButton->setEnabled(false);
   connect(connectButton, SIGNAL(clicked()), this, SLOT(accept()));
 
   newJamButton = new QPushButton(tr("&New jam"));
@@ -68,6 +69,7 @@ QString JammrConnectDialog::host() const
 
 void JammrConnectDialog::setHost(const QString &host)
 {
+  connectButton->setEnabled(!host.isEmpty());
   selectedHost = host;
 }
 


### PR DESCRIPTION
Disable the "Connect" button in the jammr server browser if no jam session has been selected.