### PR TITLE
macOS sierra build fixes

### DIFF
--- a/common/audiostream_pa.cpp
+++ b/common/audiostream_pa.cpp
@@ -337,7 +337,7 @@ audioStreamer *create_audioStreamer_PortAudio(const char *hostAPI,
 
 static void logPortAudioInfo()
 {
-  qDebug(Pa_GetVersionText());
+  qDebug("%s", Pa_GetVersionText());
 
   PaHostApiIndex api = 0;
   const PaHostApiInfo *apiInfo;

--- a/common/common.pro
+++ b/common/common.pro
@@ -3,12 +3,9 @@ CONFIG += staticlib
 QT += network
 QT -= gui
 
-# We need the include path from pkgconfig so headers are found
-CONFIG += link_pkgconfig
-PKGCONFIG += ogg vorbis vorbisenc portaudio-2.0
-
+# For third-party library headers from Homebrew
 mac {
-       INCLUDEPATH += /usr/local/Cellar/portmidi/217/include
+       INCLUDEPATH += /usr/local/include
 }
 
 QMAKE_CXXFLAGS += -Wno-write-strings

--- a/qtclient/MainWindow.cpp
+++ b/qtclient/MainWindow.cpp
@@ -723,8 +723,10 @@ void MainWindow::BeatsPerIntervalChanged(int bpi)
 
 void MainWindow::ChatMessageCallback(char **charparms, int nparms)
 {
-  QString parms[nparms];
+  QString *parms;
   int i;
+
+  parms = new QString[nparms];
 
   for (i = 0; i < nparms; i++) {
     if (charparms[i]) {
@@ -788,6 +790,8 @@ void MainWindow::ChatMessageCallback(char **charparms, int nparms)
       chatOutput->addLine(QString("[%1]").arg(i), parms[i]);
     }
   }
+
+  delete [] parms;
 }
 
 void MainWindow::ChatLinkClicked(const QUrl &url)

--- a/server/usercon.cpp
+++ b/server/usercon.cpp
@@ -167,15 +167,19 @@ void User_Connection::Send(Net_Message *msg, bool deleteAfterSend)
 void User_Connection::SendChatMessage(const QStringList &list)
 {
   mpb_chat_message newmsg;
-  QByteArray parmsUtf8[list.size()]; // holds string memory until method returns
 
-  Q_ASSERT(list.size() <= sizeof(newmsg.parms) / sizeof(newmsg.parms[0]));
+  Q_ASSERT((size_t)list.size() <= sizeof(newmsg.parms) / sizeof(newmsg.parms[0]));
+
+  QByteArray *parmsUtf8 = new QByteArray[list.size()];
 
   for (int i = 0; i < list.size(); i++) {
     parmsUtf8[i] = list.at(i).toUtf8();
     newmsg.parms[i] = parmsUtf8[i].data();
   }
+
   Send(newmsg.build());
+
+  delete [] parmsUtf8;
 }
 
 User_Connection::~User_Connection()


### PR DESCRIPTION
After upgrading to macOS Sierra and upgrading Homebrew there were a few build errors due to changing from g++ to clang.  These patches fix the errors.