### PR TITLE
Update to latest create-dmg upstream script

### DIFF
--- a/qtclient/installer/macosx/build-installer.sh
+++ b/qtclient/installer/macosx/build-installer.sh
@@ -26,7 +26,7 @@ then
 	background_opts="--window-size 800 600 --background background-$1.png --icon $1 200 351 --app-drop-link 596 351"
 fi
 
-yoursway-create-dmg/create-dmg \
+create-dmg/create-dmg \
 	--volname $1 \
 	--eula license.txt \
 	$background_opts \

--- a/qtclient/installer/macosx/create-dmg/LICENSE
+++ b/qtclient/installer/macosx/create-dmg/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2008-2014 Andrey Tarantsov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/qtclient/installer/macosx/create-dmg/README
+++ b/qtclient/installer/macosx/create-dmg/README
@@ -1,0 +1,1 @@
+From https://github.com/andreyvit/create-dmg.git, commit 5acf22fa87e1b751701f377efddc7429877ecb0a

--- a/qtclient/installer/macosx/create-dmg/README.md
+++ b/qtclient/installer/macosx/create-dmg/README.md
@@ -1,0 +1,77 @@
+create-dmg
+==========
+
+A shell script to build fancy DMGs.  
+
+
+Status and contribution policy
+------------------------------
+
+This project is maintained thanks to the contributors who send pull requests. The original author has no use for the project, so his only role is reviewing and merging pull requests.
+
+I will merge any pull request that adds something useful and does not break existing things.
+
+Starting in January 2015, everyone who gets a pull request merged gets commit access to the repository.
+  
+  
+Installation
+------------
+  
+By being a shell script, yoursway-create-dmg installation is very simple. Simply download and run.  
+  
+> git clone https://github.com/andreyvit/yoursway-create-dmg.git  
+> cd yoursway-create-dmg  
+> ./create-dmg [options]  
+  
+  
+Usage
+-----
+  
+> create-dmg [options...] [output\_name.dmg] [source\_folder]  
+
+All contents of source\_folder will be copied into the disk image.  
+  
+**Options:**  
+  
+*   **--volname [name]:** set volume name (displayed in the Finder sidebar and window title)  
+*   **--volicon [icon.icns]:** set volume icon    
+*   **--background [pic.png]:** set folder background image (provide png, gif, jpg)    
+*   **--window-pos [x y]:** set position the folder window    
+*   **--window-size [width height]:** set size of the folder window    
+*   **--text-size [text size]:** set window text size (10-16)    
+*   **--icon-size [icon size]:** set window icons size (up to 128)    
+*   **--icon [file name] [x y]:** set position of the file's icon    
+*   **--hide-extension [file name]:** hide the extension of file    
+*   **--custom-icon [file name]/[custom icon]/[sample file] [x y]:** set position and custom icon    
+*   **--app-drop-link [x y]:** make a drop link to Applications, at location x, y    
+*   **--eula [eula file]:** attach a license file to the dmg    
+*   **--no-internet-enable:** disable automatic mount&copy    
+*   **--version:** show tool version number    
+*   **-h, --help:** display the help  
+  
+  
+Example
+-------
+  
+> \#!/bin/sh  
+> test -f Application-Installer.dmg && rm Application-Installer.dmg  
+> create-dmg \  
+> --volname "Application Installer" \  
+> --volicon "application\_icon.icns" \  
+> --background "installer\_background.png" \  
+> --window-pos 200 120 \  
+> --window-size 800 400 \  
+> --icon-size 100 \  
+> --icon Application.app 200 190 \  
+> --hide-extension Application.app \  
+> --app-drop-link 600 185 \  
+> Application-Installer.dmg \  
+> source\_folder/  
+
+
+Alternatives
+------------
+
+* [node-appdmg](https://github.com/LinusU/node-appdmg)
+* [dmgbuild](https://pypi.python.org/pypi/dmgbuild)
+* see the [StackOverflow question](http://stackoverflow.com/questions/96882/how-do-i-create-a-nice-looking-dmg-for-mac-os-x-using-command-line-tools)

--- a/qtclient/installer/macosx/create-dmg/builder/create-dmg.builder
+++ b/qtclient/installer/macosx/create-dmg/builder/create-dmg.builder
@@ -1,0 +1,26 @@
+SET	app_name	create-dmg
+
+VERSION	create-dmg.cur	create-dmg	heads/master
+
+NEWDIR	build.dir	temp	%-build	-
+
+NEWFILE	create-dmg.zip	featured	%.zip	%
+
+
+COPYTO	[build.dir]
+	INTO	create-dmg	[create-dmg.cur]/create-dmg
+	INTO	sample	[create-dmg.cur]/sample
+	INTO	support	[create-dmg.cur]/support
+	
+SUBSTVARS	[build.dir<alter>]/create-dmg	[[]]
+
+
+ZIP	[create-dmg.zip]
+	INTO	[build-files-prefix]	[build.dir]
+
+
+PUT	megabox-builds	create-dmg.zip
+PUT	megabox-builds	build.log
+
+PUT	s3-builds	create-dmg.zip
+PUT	s3-builds	build.log

--- a/qtclient/installer/macosx/create-dmg/create-dmg
+++ b/qtclient/installer/macosx/create-dmg/create-dmg
@@ -28,6 +28,8 @@ function usage() {
   echo "      set position the folder window"
   echo "  --window-size width height"
   echo "      set size of the folder window"
+  echo "  --text-size text_size"
+  echo "      set window text size (10-16)"
   echo "  --icon-size icon_size"
   echo "      set window icons size (up to 128)"
   echo "  --icon file_name x y"
@@ -40,6 +42,8 @@ function usage() {
   echo "      make a drop link to Applications, at location x,y"
   echo "  --eula eula_file"
   echo "      attach a license file to the dmg"
+  echo "  --no-internet-enable"
+  echo "      disable automatic mount&copy"
   echo "  --version         show tool version number"
   echo "  -h, --help        display this help"
   exit 0
@@ -50,6 +54,7 @@ WINY=60
 WINW=500
 WINH=350
 ICON_SIZE=128
+TEXT_SIZE=16
 
 while test "${1:0:1}" = "-"; do
   case $1 in
@@ -63,9 +68,13 @@ while test "${1:0:1}" = "-"; do
       BACKGROUND_FILE="$2"
       BACKGROUND_FILE_NAME="$(basename $BACKGROUND_FILE)"
       BACKGROUND_CLAUSE="set background picture of opts to file \".background:$BACKGROUND_FILE_NAME\""
+      REPOSITION_HIDDEN_FILES_CLAUSE="set position of every item to {theBottomRightX + 100, 100}"
       shift; shift;;
     --icon-size)
       ICON_SIZE="$2"
+      shift; shift;;
+    --text-size)
+      TEXT_SIZE="$2"
       shift; shift;;
     --window-pos)
       WINX=$2; WINY=$3
@@ -78,7 +87,8 @@ while test "${1:0:1}" = "-"; do
 "
       shift; shift; shift; shift;;
     --hide-extension)
-      HIDING_CLAUSE="${HIDING_CLAUSE}set the extension hidden of item \"$2\" to true"
+      HIDING_CLAUSE="${HIDING_CLAUSE}set the extension hidden of item \"$2\" to true
+"
       shift; shift;;
     --custom-icon)
       shift; shift; shift; shift; shift;;
@@ -96,6 +106,9 @@ while test "${1:0:1}" = "-"; do
     --eula)
       EULA_RSRC=$2
       shift; shift;;
+    --no-internet-enable)
+      NOINTERNET=1
+      shift;;
     -*)
       echo "Unknown option $1. Run with --help for help."
       exit 1;;
@@ -107,15 +120,16 @@ test -z "$2" && {
   exit 1
 }
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 DMG_PATH="$1"
 DMG_DIRNAME="$(dirname "$DMG_PATH")"
-DMG_DIR="$(cd $DMG_DIRNAME > /dev/null; pwd)"
+DMG_DIR="$(cd "$DMG_DIRNAME" > /dev/null; pwd)"
 DMG_NAME="$(basename "$DMG_PATH")"
 DMG_TEMP_NAME="$DMG_DIR/rw.${DMG_NAME}"
 SRC_FOLDER="$(cd "$2" > /dev/null; pwd)"
 test -z "$VOLUME_NAME" && VOLUME_NAME="$(basename "$DMG_PATH" .dmg)"
 
-AUX_PATH="$(dirname $0)/support"
+AUX_PATH="$SCRIPT_DIR/support"
 
 test -d "$AUX_PATH" || {
   echo "Cannot find support directory: $AUX_PATH"
@@ -167,7 +181,7 @@ fi
 
 # run applescript
 APPLESCRIPT=$(mktemp -t createdmg)
-cat "$AUX_PATH/template.applescript" | sed -e "s/WINX/$WINX/g" -e "s/WINY/$WINY/g" -e "s/WINW/$WINW/g" -e "s/WINH/$WINH/g" -e "s/BACKGROUND_CLAUSE/$BACKGROUND_CLAUSE/g" -e "s/ICON_SIZE/$ICON_SIZE/g" | perl -pe  "s/POSITION_CLAUSE/$POSITION_CLAUSE/g" | perl -pe "s/APPLICATION_CLAUSE/$APPLICATION_CLAUSE/g" | perl -pe "s/HIDING_CLAUSE/$HIDING_CLAUSE/" >"$APPLESCRIPT"
+cat "$AUX_PATH/template.applescript" | sed -e "s/WINX/$WINX/g" -e "s/WINY/$WINY/g" -e "s/WINW/$WINW/g" -e "s/WINH/$WINH/g" -e "s/BACKGROUND_CLAUSE/$BACKGROUND_CLAUSE/g" -e "s/REPOSITION_HIDDEN_FILES_CLAUSE/$REPOSITION_HIDDEN_FILES_CLAUSE/g" -e "s/ICON_SIZE/$ICON_SIZE/g" -e "s/TEXT_SIZE/$TEXT_SIZE/g" | perl -pe  "s/POSITION_CLAUSE/$POSITION_CLAUSE/g" | perl -pe "s/APPLICATION_CLAUSE/$APPLICATION_CLAUSE/g" | perl -pe "s/HIDING_CLAUSE/$HIDING_CLAUSE/" >"$APPLESCRIPT"
 
 echo "Running Applescript: /usr/bin/osascript \"${APPLESCRIPT}\" \"${VOLUME_NAME}\""
 "/usr/bin/osascript" "${APPLESCRIPT}" "${VOLUME_NAME}" || true
@@ -204,6 +218,12 @@ rm -f "${DMG_TEMP_NAME}"
 if [ ! -z "${EULA_RSRC}" -a "${EULA_RSRC}" != "-null-" ]; then
         echo "adding EULA resources"
         "${AUX_PATH}/dmg-license.py" "${DMG_DIR}/${DMG_NAME}" "${EULA_RSRC}"
+fi
+
+if [ ! -z "${NOINTERNET}" -a "${NOINTERNET}" == 1 ]; then
+        echo "not setting 'internet-enable' on the dmg"
+else
+        hdiutil internet-enable -yes "${DMG_DIR}/${DMG_NAME}"
 fi
 
 echo "Disk image done"

--- a/qtclient/installer/macosx/create-dmg/sample
+++ b/qtclient/installer/macosx/create-dmg/sample
@@ -1,0 +1,3 @@
+#! /bin/bash
+test -f test2.dmg && rm test2.dmg
+./create-dmg --window-size 500 300 --background ~/Projects/eclipse-osx-repackager/build/background.gif --icon-size 96 --volname "Hyper Foo" --app-drop-link 380 205 --icon "Eclipse OS X Repackager" 110 205 test2.dmg /Users/andreyvit/Projects/eclipse-osx-repackager/temp/Eclipse\ OS\ X\ Repackager\ r10/

--- a/qtclient/installer/macosx/create-dmg/support/dmg-license.py
+++ b/qtclient/installer/macosx/create-dmg/support/dmg-license.py
@@ -4,7 +4,7 @@ This script adds a license file to a DMG. Requires Xcode and a plain ascii text
 license file.
 Obviously only runs on a Mac.
 
-Copyright (C) 2011 Jared Hobbs
+Copyright (C) 2011-2013 Jared Hobbs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -48,46 +48,71 @@ def main(options, args):
     dmgFile, license = args
     with mktemp('.') as tmpFile:
         with open(tmpFile, 'w') as f:
-            f.write("""data 'LPic' (5000) {
-    $"0002 0011 0003 0001 0000 0000 0002 0000"
-    $"0000 000E 0006 0001 0005 0007 0000 0007"
-    $"0008 0000 0047 0009 0000 0034 000A 0001"
-    $"0035 000B 0001 0020 000C 0000 0011 000D"
-    $"0000 005B 0004 0000 0033 000F 0001 000C"
-    $"0010 0000 000B 000E 0000"
+            f.write("""data 'TMPL' (128, "LPic") {
+        $"1344 6566 6175 6C74 204C 616E 6775 6167"
+        $"6520 4944 4457 5244 0543 6F75 6E74 4F43"
+        $"4E54 042A 2A2A 2A4C 5354 430B 7379 7320"
+        $"6C61 6E67 2049 4444 5752 441E 6C6F 6361"
+        $"6C20 7265 7320 4944 2028 6F66 6673 6574"
+        $"2066 726F 6D20 3530 3030 4457 5244 1032"
+        $"2D62 7974 6520 6C61 6E67 7561 6765 3F44"
+        $"5752 4404 2A2A 2A2A 4C53 5445"
+};
+
+data 'LPic' (5000) {
+        $"0000 0002 0000 0000 0000 0000 0004 0000"
+};
+
+data 'STR#' (5000, "English buttons") {
+        $"0006 0D45 6E67 6C69 7368 2074 6573 7431"
+        $"0541 6772 6565 0844 6973 6167 7265 6505"
+        $"5072 696E 7407 5361 7665 2E2E 2E7A 4966"
+        $"2079 6F75 2061 6772 6565 2077 6974 6820"
+        $"7468 6520 7465 726D 7320 6F66 2074 6869"
+        $"7320 6C69 6365 6E73 652C 2063 6C69 636B"
+        $"2022 4167 7265 6522 2074 6F20 6163 6365"
+        $"7373 2074 6865 2073 6F66 7477 6172 652E"
+        $"2020 4966 2079 6F75 2064 6F20 6E6F 7420"
+        $"6167 7265 652C 2070 7265 7373 2022 4469"
+        $"7361 6772 6565 2E22"
+};
+
+data 'STR#' (5002, "English") {
+        $"0006 0745 6E67 6C69 7368 0541 6772 6565"
+        $"0844 6973 6167 7265 6505 5072 696E 7407"
+        $"5361 7665 2E2E 2E7B 4966 2079 6F75 2061"
+        $"6772 6565 2077 6974 6820 7468 6520 7465"
+        $"726D 7320 6F66 2074 6869 7320 6C69 6365"
+        $"6E73 652C 2070 7265 7373 2022 4167 7265"
+        $"6522 2074 6F20 696E 7374 616C 6C20 7468"
+        $"6520 736F 6674 7761 7265 2E20 2049 6620"
+        $"796F 7520 646F 206E 6F74 2061 6772 6565"
+        $"2C20 7072 6573 7320 2244 6973 6167 7265"
+        $"6522 2E"
 };\n\n""")
             with open(license, 'r') as l:
-                f.write('data \'TEXT\' (5002, "English") {\n')
+                kind = 'RTF ' if license.lower().endswith('.rtf') else 'TEXT'
+                f.write('data \'%s\' (5000, "English") {\n' % kind)
+                def escape(s):
+                    return s.strip().replace('\\', '\\\\').replace('"', '\\"')
+
                 for line in l:
                     if len(line) < 1000:
-                        f.write('    "' + line.strip().replace('"', '\\"') +
-                                '\\n"\n')
+                        f.write('    "' + escape(line) + '\\n"\n')
                     else:
                         for liner in line.split('.'):
-                            f.write('    "' +
-                                    liner.strip().replace('"', '\\"') +
-                                    '. \\n"\n')
+                            f.write('    "' + escape(liner) + '. \\n"\n')
                 f.write('};\n\n')
-            f.write("""resource 'STR#' (5002, "English") {
-    {
-        "English",
-        "Agree",
-        "Disagree",
-        "Print",
-        "Save...",
-        "IMPORTANT - By clicking on the \\"Agree\\" button, you agree "
-        "to be bound by the terms of the License Agreement.",
-        "Software License Agreement",
-        "This text cannot be saved. This disk may be full or locked, or the "
-        "file may be locked.",
-        "Unable to print. Make sure you have selected a printer."
-    }
-};""")
-        os.system('/usr/bin/hdiutil unflatten -quiet "%s"' % dmgFile)
-        os.system('%s "%s/"*.r %s -a -o "%s"' %
-                  (options.rez, options.flat_carbon, tmpFile, dmgFile))
-
-        os.system('/usr/bin/hdiutil flatten -quiet "%s"' % dmgFile)
+            f.write("""data 'styl' (5000, "English") {
+        $"0003 0000 0000 000C 0009 0014 0000 0000"
+        $"0000 0000 0000 0000 0027 000C 0009 0014"
+        $"0100 0000 0000 0000 0000 0000 002A 000C"
+        $"0009 0014 0000 0000 0000 0000 0000"
+};\n""")
+        os.system('hdiutil unflatten -quiet "%s"' % dmgFile)
+        ret = os.system('%s -a %s -o "%s"' %
+                        (options.rez, tmpFile, dmgFile))
+        os.system('hdiutil flatten -quiet "%s"' % dmgFile)
         if options.compression is not None:
             os.system('cp %s %s.temp.dmg' % (dmgFile, dmgFile))
             os.remove(dmgFile)
@@ -98,13 +123,17 @@ def main(options, args):
                 os.system('hdiutil convert %s.temp.dmg -format ' % dmgFile +
                           'UDZO -imagekey zlib-devel=9 -o %s' % dmgFile)
             os.remove('%s.temp.dmg' % dmgFile)
-    print "Successfully added license to '%s'" % dmgFile
+    if ret == 0:
+        print "Successfully added license to '%s'" % dmgFile
+    else:
+        print "Failed to add license to '%s'" % dmgFile
 
 if __name__ == '__main__':
     parser = optparse.OptionParser()
     parser.set_usage("""%prog <dmgFile> <licenseFile> [OPTIONS]
   This program adds a software license agreement to a DMG file.
-  It requires Xcode and a plain ascii text <licenseFile>.
+  It requires Xcode and either a plain ascii text <licenseFile>
+  or a <licenseFile.rtf> with the RTF contents.
 
   See --help for more details.""")
     parser.add_option(
@@ -113,15 +142,6 @@ if __name__ == '__main__':
         action='store',
         default='/Applications/Xcode.app/Contents/Developer/Tools/Rez',
         help='The path to the Rez tool. Defaults to %default'
-    )
-    parser.add_option(
-        '--flat-carbon',
-        '-f',
-        action='store',
-        default='/Applications/Xcode.app/Contents/Developer/Platforms'
-                '/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk'
-                '/Developer/Headers/FlatCarbon',
-        help='The path to the FlatCarbon headers. Defaults to %default'
     )
     parser.add_option(
         '--compression',
@@ -133,8 +153,10 @@ if __name__ == '__main__':
              'Choices are bz2 and gz.'
     )
     options, args = parser.parse_args()
-    cond = len(args) != 2 or not os.path.exists(options.rez) \
-        or not os.path.exists(options.flat_carbon)
+    cond = len(args) != 2
+    if not os.path.exists(options.rez):
+        print 'Failed to find Rez at "%s"!\n' % options.rez
+        cond = True
     if cond:
         parser.print_usage()
         sys.exit(1)

--- a/qtclient/installer/macosx/create-dmg/support/template.applescript
+++ b/qtclient/installer/macosx/create-dmg/support/template.applescript
@@ -18,11 +18,13 @@ on run (volumeName)
 				set statusbar visible to false
 				set the bounds to {theXOrigin, theYOrigin, theBottomRightX, theBottomRightY}
 				set statusbar visible to false
+				REPOSITION_HIDDEN_FILES_CLAUSE
 			end tell
 			
 			set opts to the icon view options of container window
 			tell opts
 				set icon size to ICON_SIZE
+				set text size to TEXT_SIZE
 				set arrangement to not arranged
 			end tell
 			BACKGROUND_CLAUSE

--- a/qtclient/installer/macosx/yoursway-create-dmg/README
+++ b/qtclient/installer/macosx/yoursway-create-dmg/README
@@ -1,1 +1,0 @@
-From git://github.com/andreyvit/yoursway-create-dmg.git, commit 755381fd47802a2bf08307b9c583e775d785a08e


### PR DESCRIPTION
The upstream git repo has been renamed.  It contains new code that works
on macOS Sierra.  The previously imported version relied on FlatCarbon
headers which are no longer available in the expected location.

Signed-off-by: Stefan Hajnoczi <stefanha@gmail.com>