### PR TITLE
wahjamsrv: add SslVerify yes/no option

### DIFF
--- a/server/Server.cpp
+++ b/server/Server.cpp
@@ -96,6 +96,13 @@ bool Server::setConfig(ServerConfig *config_)
 {
   config = config_;
 
+  /* Enable/disable SSL certificate verification */
+  QSslConfiguration sslConfig = QSslConfiguration::defaultConfiguration();
+  sslConfig.setPeerVerifyMode(config->sslVerify ?
+                              QSslSocket::AutoVerifyPeer :
+                              QSslSocket::QueryPeer);
+  QSslConfiguration::setDefaultConfiguration(sslConfig);
+
   group->m_max_users = config->maxUsers;
   if (!group->m_topictext.Get()[0]) {
       group->m_topictext.Set(config->defaultTopic.Get());

--- a/server/Server.h
+++ b/server/Server.h
@@ -87,6 +87,7 @@ struct ServerConfig
   WDL_PtrList<UserPassEntry> userlist;
   QUrl jammrApiUrl;
   QString jammrServerName;
+  bool sslVerify;
 };
 
 class Server : public QObject

--- a/server/ninjamsrv.cpp
+++ b/server/ninjamsrv.cpp
@@ -425,6 +425,18 @@ static int ConfigOnToken(ServerConfig *config, LineParser *lp)
     config->jammrApiUrl.setPassword(lp->gettoken_str(3));
     config->jammrServerName = lp->gettoken_str(4);
   }
+  else if (token == QString("SslVerify").toLower())
+  {
+    if (lp->getnumtokens() != 2) {
+      return -1;
+    }
+
+    int x=lp->gettoken_enum(1,"no\0yes\0");
+    if (x < 0) {
+      return -2;
+    }
+    config->sslVerify = x;
+  }
   else return -3;
   return 0;
 }
@@ -468,6 +480,7 @@ static int ReadConfig(ServerConfig *config, char *configfile)
   config->acl.clear();
   config->jammrApiUrl.clear();
   config->jammrServerName.clear();
+  config->sslVerify = true;
 
   int x;
   for(x=0; x < config->userlist.GetSize(); x++)


### PR DESCRIPTION
It can be useful to disable SSL certificate verification in development
environments that use self-signed certificates.  Add a new wahjamsrv
configuration file option called "SslVerify" that takes a "yes" or "no"
value (default "yes").

Signed-off-by: Stefan Hajnoczi <stefanha@gmail.com>