### PR TITLE
request audio permission on mac

### DIFF
--- a/qtclient/Info.plist
+++ b/qtclient/Info.plist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist SYSTEM "file://localhost/System/Library/DTDs/PropertyList.dtd">
-<plist version="0.9">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
 <dict>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
@@ -20,6 +20,8 @@
 	<string>@BUNDLEIDENTIFIER@</string>
 	<key>CFBundleDisplayName</key>
 	<string>@EXECUTABLE@</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>This app needs microphone access so it can hear what you&apos;re playing</string>
 	<key>CFBundleName</key>
 	<string>@EXECUTABLE@</string>
 </dict>

--- a/qtclient/PortAudioStreamer.cpp
+++ b/qtclient/PortAudioStreamer.cpp
@@ -23,6 +23,9 @@
 #include <pa_jack.h>
 #endif
 #include "PortAudioStreamer.h"
+#ifdef Q_OS_MAC
+#import "requestmicpermission.h"
+#endif
 
 static void logPortAudioError(const char *msg, PaError error)
 {
@@ -547,6 +550,10 @@ bool portAudioInit()
 #ifdef Q_OS_LINUX
   /* Set the name for JACK ports */
   PaJack_SetClientName(APPNAME);
+#endif
+
+#ifdef Q_OS_MAC
+  RequestMicPermission::openMic();
 #endif
 
   PaError error = Pa_Initialize();

--- a/qtclient/qtclient.pro
+++ b/qtclient/qtclient.pro
@@ -128,7 +128,7 @@ win32 {
 }
 
 mac {
-	LIBS += -framework Foundation -framework AudioUnit -framework AppKit
+	LIBS += -framework Foundation -framework AudioUnit -framework AppKit -framework AVFoundation
 	QMAKE_TARGET_BUNDLE_PREFIX = $$split(ORGDOMAIN, .)
 	QMAKE_TARGET_BUNDLE_PREFIX = $$reverse(QMAKE_TARGET_BUNDLE_PREFIX)
 	QMAKE_TARGET_BUNDLE_PREFIX = $$join(QMAKE_TARGET_BUNDLE_PREFIX, .)
@@ -169,7 +169,7 @@ HEADERS += EffectPlugin.h
 HEADERS += VSTPlugin.h
 mac:HEADERS += PmEventParser.h
 mac:HEADERS += AudioUnitPlugin.h
-mac:HEADERS += createuiwidget.h
+mac:HEADERS += createuiwidget.h requestmicpermission.h
 HEADERS += EffectProcessor.h
 HEADERS += PortMidiStreamer.h
 HEADERS += screensleep.h
@@ -202,7 +202,7 @@ SOURCES += EffectPlugin.cpp
 SOURCES += VSTPlugin.cpp
 mac:SOURCES += PmEventParser.cpp
 mac:SOURCES += AudioUnitPlugin.cpp
-mac:OBJECTIVE_SOURCES += createuiwidget.mm
+mac:OBJECTIVE_SOURCES += createuiwidget.mm requestmicpermission.mm
 SOURCES += EffectProcessor.cpp
 SOURCES += PortMidiStreamer.cpp
 win32 {

--- a/qtclient/requestmicpermission.h
+++ b/qtclient/requestmicpermission.h
@@ -1,0 +1,8 @@
+class RequestMicPermission {
+
+public:
+  RequestMicPermission() {}
+  ~RequestMicPermission() {}
+
+  static bool openMic();
+};

--- a/qtclient/requestmicpermission.mm
+++ b/qtclient/requestmicpermission.mm
@@ -1,0 +1,33 @@
+#import "requestmicpermission.h"
+#import "AVFoundation/AVFoundation.h"
+
+bool RequestMicPermission::openMic()
+{
+    if (@available(macOS 10.14, *)) {
+
+        AVAuthorizationStatus st = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio];
+        if (st == AVAuthorizationStatusAuthorized) {
+          return true;
+        }
+
+        dispatch_group_t group = dispatch_group_create();
+
+        __block bool accessGranted = false;
+
+        if (st != AVAuthorizationStatusAuthorized) {
+          dispatch_group_enter(group);
+          [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio completionHandler:^(BOOL granted) {
+
+              accessGranted = granted;
+              NSLog(@"Granted!");
+              dispatch_group_leave(group);
+            }];
+        }
+
+        dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(5.0 * NSEC_PER_SEC)));
+
+        return accessGranted;
+    } else  {
+        return true;
+    }
+}


### PR DESCRIPTION
Symptom: when you build Wahjam on macOS Catalina without signing it, everything seems to work except that it doesn't get an input from the microphone. So you join a  jam and nobody else can hear what you're playing/saying.

This commit introduces some AVFoundation framework calls to  detect if we  have the appropriate permission, and request
it if not.

I haven't tested this with code signing - my assumption (I'm not a Mac expert by a long stretch) is that I would need an Apple developer account of some kind to sign  code.

